### PR TITLE
feat: refine confidence gate and fallback trace

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -36,5 +36,6 @@ Invoke-WebRequest http://localhost:8080/swagger-ui.html
 - `FLOWMIND_REDIS_ENABLED`
 - `FLOWMIND_OPENAI_ENABLED`
 - `FLOWMIND_SWAGGER_ENABLED`
+- `FLOWMIND_CONFIDENCE_THRESHOLD` (default: `0.65`)
 
 The bootstrap defaults are set to start without requiring a live database connection.

--- a/backend/src/main/java/com/flowmind/config/FlowMindRuntimeProperties.java
+++ b/backend/src/main/java/com/flowmind/config/FlowMindRuntimeProperties.java
@@ -4,9 +4,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "flowmind")
 public record FlowMindRuntimeProperties(
-    String applicationName, Integration integration, Storage storage) {
+    String applicationName, Integration integration, Storage storage, Dispatch dispatch) {
 
   public record Integration(boolean redisEnabled, boolean openaiEnabled) {}
 
   public record Storage(boolean databaseEnabled, boolean flywayEnabled) {}
+
+  public record Dispatch(double confidenceThreshold) {}
 }

--- a/backend/src/main/java/com/flowmind/dispatch/model/FallbackReason.java
+++ b/backend/src/main/java/com/flowmind/dispatch/model/FallbackReason.java
@@ -1,0 +1,7 @@
+package com.flowmind.dispatch.model;
+
+public enum FallbackReason {
+  LOW_CONFIDENCE,
+  COMPLEX_REQUEST,
+  EMOTION_HEAVY
+}

--- a/backend/src/main/java/com/flowmind/dispatch/runtime/DispatchTrace.java
+++ b/backend/src/main/java/com/flowmind/dispatch/runtime/DispatchTrace.java
@@ -10,4 +10,5 @@ public record DispatchTrace(
     IntentType intent,
     double confidence,
     RouteType route,
-    String reason) {}
+    String reason,
+    Long latencyMs) {}

--- a/backend/src/main/java/com/flowmind/dispatch/service/DispatchService.java
+++ b/backend/src/main/java/com/flowmind/dispatch/service/DispatchService.java
@@ -1,7 +1,9 @@
 package com.flowmind.dispatch.service;
 
+import com.flowmind.config.FlowMindRuntimeProperties;
 import com.flowmind.dispatch.model.DispatchRequest;
 import com.flowmind.dispatch.model.DispatchResponse;
+import com.flowmind.dispatch.model.FallbackReason;
 import com.flowmind.dispatch.model.IntentType;
 import com.flowmind.dispatch.model.RouteType;
 import com.flowmind.dispatch.runtime.ConversationLogEntry;
@@ -22,10 +24,12 @@ public class DispatchService {
   private final ScenarioExecutor scenarioExecutor;
   private final LlmGateway llmGateway;
   private final DispatchTelemetryService telemetryService;
+  private final double confidenceThreshold;
 
   private final Map<String, SessionContext> sessions = new ConcurrentHashMap<>();
 
   public DispatchService(
+      FlowMindRuntimeProperties runtimeProperties,
       IntentClassifier intentClassifier,
       SlotService slotService,
       ScenarioExecutor scenarioExecutor,
@@ -36,6 +40,7 @@ public class DispatchService {
     this.scenarioExecutor = scenarioExecutor;
     this.llmGateway = llmGateway;
     this.telemetryService = telemetryService;
+    this.confidenceThreshold = runtimeProperties.dispatch().confidenceThreshold();
   }
 
   public DispatchResponse dispatch(DispatchRequest request) {
@@ -61,10 +66,13 @@ public class DispatchService {
     slotService.extractAndMerge(intent, request.message(), context);
     List<String> missingSlots = slotService.missingRequiredSlots(intent, context);
 
-    String fallbackReason = fallbackReason(intent, confidence, request.message());
+    FallbackReason fallbackReason = fallbackReason(intent, confidence, request.message());
     DispatchResponse response;
     RouteType route;
-    if (!missingSlots.isEmpty() && intent != IntentType.UNKNOWN) {
+    if (fallbackReason != null) {
+      route = RouteType.LLM;
+      response = llmGateway.fallback(intent, fallbackReason, context.slots());
+    } else if (!missingSlots.isEmpty() && intent != IntentType.UNKNOWN) {
       route = RouteType.SCENARIO;
       response =
           new DispatchResponse(
@@ -74,14 +82,12 @@ public class DispatchService {
               "CLARIFY",
               null,
               context.slots());
-    } else if (fallbackReason != null) {
-      route = RouteType.LLM;
-      response = llmGateway.fallback(intent, fallbackReason, context.slots());
     } else {
       route = RouteType.SCENARIO;
       response = scenarioExecutor.execute(intent, context);
     }
 
+    Duration latency = Duration.between(start, Instant.now());
     DispatchTrace trace =
         new DispatchTrace(
             Instant.now(),
@@ -89,12 +95,13 @@ public class DispatchService {
             intent,
             confidence,
             route,
-            fallbackReason == null ? "SCENARIO" : fallbackReason);
+            fallbackReason == null ? "SCENARIO" : fallbackReason.name(),
+            latency.toMillis());
     telemetryService.saveTrace(trace);
     telemetryService.saveConversation(
         new ConversationLogEntry(
             Instant.now(), sessionId, request.message(), response.message(), route));
-    telemetryService.recordMetrics(route, fallbackReason, Duration.between(start, Instant.now()));
+    telemetryService.recordMetrics(route, fallbackReason, latency);
 
     return response;
   }
@@ -103,17 +110,33 @@ public class DispatchService {
     return telemetryService.snapshot();
   }
 
-  private String fallbackReason(IntentType intent, double confidence, String message) {
+  private FallbackReason fallbackReason(IntentType intent, double confidence, String message) {
     String text = message == null ? "" : message.toLowerCase();
-    if (confidence < 0.5 || intent == IntentType.UNKNOWN) {
-      return "LOW_CONFIDENCE";
+    if (containsEmotionSignal(text)) {
+      return FallbackReason.EMOTION_HEAVY;
     }
-    if (text.contains("그리고") || text.contains("및")) {
-      return "COMPLEX_REQUEST";
+    if (containsComplexSignal(text)) {
+      return FallbackReason.COMPLEX_REQUEST;
     }
-    if (text.contains("짜증") || text.contains("화나") || text.contains("불만")) {
-      return "EMOTION_HEAVY";
+    if (confidence < confidenceThreshold || intent == IntentType.UNKNOWN) {
+      return FallbackReason.LOW_CONFIDENCE;
     }
     return null;
+  }
+
+  private boolean containsComplexSignal(String text) {
+    return text.contains("그리고")
+        || text.contains("및")
+        || text.contains("또")
+        || text.contains("동시에")
+        || text.contains("같이");
+  }
+
+  private boolean containsEmotionSignal(String text) {
+    return text.contains("짜증")
+        || text.contains("화나")
+        || text.contains("불만")
+        || text.contains("화가")
+        || text.contains("엉망");
   }
 }

--- a/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
+++ b/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
@@ -1,5 +1,6 @@
 package com.flowmind.dispatch.service;
 
+import com.flowmind.dispatch.model.FallbackReason;
 import com.flowmind.dispatch.model.RouteType;
 import com.flowmind.dispatch.runtime.ConversationLogEntry;
 import com.flowmind.dispatch.runtime.DispatchTrace;
@@ -27,13 +28,14 @@ public class DispatchTelemetryService {
     conversations.add(entry);
   }
 
-  public synchronized void recordMetrics(RouteType route, String reason, Duration latency) {
+  public synchronized void recordMetrics(
+      RouteType route, FallbackReason fallbackReason, Duration latency) {
     total.incrementAndGet();
     latencyTotalMs += latency.toMillis();
     if (route == RouteType.LLM) {
       fallback.incrementAndGet();
     }
-    if ("LOW_CONFIDENCE".equals(reason)) {
+    if (fallbackReason == FallbackReason.LOW_CONFIDENCE) {
       lowConfidence.incrementAndGet();
     }
   }

--- a/backend/src/main/java/com/flowmind/dispatch/service/LlmGateway.java
+++ b/backend/src/main/java/com/flowmind/dispatch/service/LlmGateway.java
@@ -1,6 +1,7 @@
 package com.flowmind.dispatch.service;
 
 import com.flowmind.dispatch.model.DispatchResponse;
+import com.flowmind.dispatch.model.FallbackReason;
 import com.flowmind.dispatch.model.IntentType;
 import com.flowmind.dispatch.model.RouteType;
 import java.util.Map;
@@ -10,13 +11,13 @@ import org.springframework.stereotype.Component;
 public class LlmGateway {
 
   public DispatchResponse fallback(
-      IntentType intent, String fallbackReason, Map<String, String> slots) {
+      IntentType intent, FallbackReason fallbackReason, Map<String, String> slots) {
     return new DispatchResponse(
         RouteType.LLM,
         intent,
         "상황을 정확히 파악하기 위해 상담사를 연결하거나 추가 정보를 확인하겠습니다.",
         "LLM_FALLBACK",
-        fallbackReason,
+        fallbackReason.name(),
         slots);
   }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -65,4 +65,6 @@ flowmind:
   storage:
     database-enabled: ${FLOWMIND_DB_ENABLED:false}
     flyway-enabled: ${FLOWMIND_FLYWAY_ENABLED:false}
+  dispatch:
+    confidence-threshold: ${FLOWMIND_CONFIDENCE_THRESHOLD:0.65}
 

--- a/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
+++ b/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
@@ -61,6 +61,36 @@ class DispatchControllerTest {
                                 """))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.route").value("LLM"))
+        .andExpect(jsonPath("$.fallbackReason").value("EMOTION_HEAVY"));
+  }
+
+  @Test
+  void complexRequestShouldRouteToFallback() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/dispatch")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                                {"sessionId":"s4","message":"계좌 정보랑 거래내역을 동시에 그리고 같이 확인해줘"}
+                                """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.route").value("LLM"))
+        .andExpect(jsonPath("$.fallbackReason").value("COMPLEX_REQUEST"));
+  }
+
+  @Test
+  void lowConfidenceShouldRouteToFallback() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/dispatch")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                                {"sessionId":"s5","message":"아무튼 뭔가 좀 해줘"}
+                                """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.route").value("LLM"))
         .andExpect(jsonPath("$.fallbackReason").value("LOW_CONFIDENCE"));
   }
 

--- a/docs/planning/exec-plans/active/finance-voiceops-mvp.md
+++ b/docs/planning/exec-plans/active/finance-voiceops-mvp.md
@@ -91,3 +91,7 @@ FlowMind Finance VoiceOps MVP 구현 계획
 ## 진행 상태
 
 - `in_progress`
+- 2026-04-28 업데이트:
+  - `FLOWMIND_CONFIDENCE_THRESHOLD` 설정 기반 confidence gate 적용
+  - fallback reason 코드 분리(`LOW_CONFIDENCE`, `COMPLEX_REQUEST`, `EMOTION_HEAVY`)
+  - dispatch trace에 `latencyMs` 필드 추가


### PR DESCRIPTION
## 변경 내용
- confidence gate를 설정 기반으로 분리(FLOWMIND_CONFIDENCE_THRESHOLD)
- fallback reason 코드를 LOW_CONFIDENCE/COMPLEX_REQUEST/EMOTION_HEAVY로 명확화
- 복합 요청/감정 요청은 슬롯질의보다 우선 LLM fallback 라우팅
- dispatch trace에 latencyMs 저장 필드 추가
- fallback 3종 검증 테스트 추가
- exec-plan/README 문서 업데이트

## 변경 파일
- backend/src/main/java/com/flowmind/config/FlowMindRuntimeProperties.java
- backend/src/main/java/com/flowmind/dispatch/model/FallbackReason.java
- backend/src/main/java/com/flowmind/dispatch/runtime/DispatchTrace.java
- backend/src/main/java/com/flowmind/dispatch/service/DispatchService.java
- backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
- backend/src/main/java/com/flowmind/dispatch/service/LlmGateway.java
- backend/src/main/resources/application.yml
- backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
- backend/README.md
- docs/planning/exec-plans/active/finance-voiceops-mvp.md

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- 위 변경 파일 목록 참조

## 핸드오프: 검증 결과
- spotlessCheck/test 통과
- fallback 조건 3종 테스트 통과

## 핸드오프: 남은 리스크
- 현재 fallback 조건은 키워드/규칙 기반이므로 실제 운영 데이터에서 false positive/negative 튜닝이 추가로 필요

## 관련 이슈
- closes #13