### PR TITLE
feat: add fallback reason metrics and trace query api

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -20,6 +20,7 @@ cd backend
 Invoke-WebRequest http://localhost:8080/api/health
 Invoke-WebRequest http://localhost:8080/actuator/health
 Invoke-WebRequest http://localhost:8080/api/dispatch/metrics
+Invoke-WebRequest "http://localhost:8080/api/dispatch/traces?limit=10"
 Invoke-WebRequest http://localhost:8080/swagger-ui.html
 .\gradlew.bat test
 .\\gradlew.bat spotlessCheck

--- a/backend/src/main/java/com/flowmind/dispatch/DispatchController.java
+++ b/backend/src/main/java/com/flowmind/dispatch/DispatchController.java
@@ -2,13 +2,16 @@ package com.flowmind.dispatch;
 
 import com.flowmind.dispatch.model.DispatchRequest;
 import com.flowmind.dispatch.model.DispatchResponse;
+import com.flowmind.dispatch.runtime.DispatchTrace;
 import com.flowmind.dispatch.service.DispatchService;
 import com.flowmind.dispatch.service.DispatchTelemetryService;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,5 +32,10 @@ public class DispatchController {
   @GetMapping("/metrics")
   public ResponseEntity<DispatchTelemetryService.MetricsSnapshot> metrics() {
     return ResponseEntity.ok(dispatchService.metrics());
+  }
+
+  @GetMapping("/traces")
+  public ResponseEntity<List<DispatchTrace>> traces(@RequestParam(defaultValue = "20") int limit) {
+    return ResponseEntity.ok(dispatchService.recentTraces(limit));
   }
 }

--- a/backend/src/main/java/com/flowmind/dispatch/service/DispatchService.java
+++ b/backend/src/main/java/com/flowmind/dispatch/service/DispatchService.java
@@ -110,6 +110,10 @@ public class DispatchService {
     return telemetryService.snapshot();
   }
 
+  public List<DispatchTrace> recentTraces(int limit) {
+    return telemetryService.recentTraces(limit);
+  }
+
   private FallbackReason fallbackReason(IntentType intent, double confidence, String message) {
     String text = message == null ? "" : message.toLowerCase();
     if (containsEmotionSignal(text)) {

--- a/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
+++ b/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
@@ -6,7 +6,9 @@ import com.flowmind.dispatch.runtime.ConversationLogEntry;
 import com.flowmind.dispatch.runtime.DispatchTrace;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.springframework.stereotype.Service;
 
@@ -18,7 +20,15 @@ public class DispatchTelemetryService {
   private final AtomicInteger total = new AtomicInteger();
   private final AtomicInteger fallback = new AtomicInteger();
   private final AtomicInteger lowConfidence = new AtomicInteger();
+  private final EnumMap<FallbackReason, AtomicInteger> fallbackReasonCounts =
+      new EnumMap<>(FallbackReason.class);
   private long latencyTotalMs = 0L;
+
+  public DispatchTelemetryService() {
+    for (FallbackReason reason : FallbackReason.values()) {
+      fallbackReasonCounts.put(reason, new AtomicInteger());
+    }
+  }
 
   public synchronized void saveTrace(DispatchTrace trace) {
     traces.add(trace);
@@ -38,6 +48,9 @@ public class DispatchTelemetryService {
     if (fallbackReason == FallbackReason.LOW_CONFIDENCE) {
       lowConfidence.incrementAndGet();
     }
+    if (fallbackReason != null) {
+      fallbackReasonCounts.get(fallbackReason).incrementAndGet();
+    }
   }
 
   public synchronized MetricsSnapshot snapshot() {
@@ -46,12 +59,28 @@ public class DispatchTelemetryService {
     double misclassificationRate =
         totalCount == 0 ? 0.0 : (double) lowConfidence.get() / totalCount;
     double avgLatency = totalCount == 0 ? 0.0 : (double) latencyTotalMs / totalCount;
-    return new MetricsSnapshot(totalCount, fallbackRate, misclassificationRate, avgLatency);
+    return new MetricsSnapshot(
+        totalCount, fallbackRate, misclassificationRate, avgLatency, fallbackReasonSnapshot());
+  }
+
+  public synchronized List<DispatchTrace> recentTraces(int limit) {
+    int safeLimit = Math.max(limit, 1);
+    int fromIndex = Math.max(traces.size() - safeLimit, 0);
+    return new ArrayList<>(traces.subList(fromIndex, traces.size()));
+  }
+
+  private Map<String, Integer> fallbackReasonSnapshot() {
+    Map<String, Integer> snapshot = new java.util.LinkedHashMap<>();
+    for (FallbackReason reason : FallbackReason.values()) {
+      snapshot.put(reason.name(), fallbackReasonCounts.get(reason).get());
+    }
+    return snapshot;
   }
 
   public record MetricsSnapshot(
       int totalRequests,
       double fallbackRate,
       double misclassificationRate,
-      double averageLatencyMs) {}
+      double averageLatencyMs,
+      Map<String, Integer> fallbackReasonCounts) {}
 }

--- a/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
+++ b/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
@@ -97,10 +97,43 @@ class DispatchControllerTest {
   @Test
   void metricsEndpointShouldReturnSnapshot() throws Exception {
     mockMvc
+        .perform(
+            post("/api/dispatch")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                                {"sessionId":"m1","message":"아무튼 뭔가 좀 해줘"}
+                                """))
+        .andExpect(status().isOk());
+
+    mockMvc
         .perform(get("/api/dispatch/metrics"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.totalRequests").exists())
         .andExpect(jsonPath("$.fallbackRate").exists())
-        .andExpect(jsonPath("$.averageLatencyMs").exists());
+        .andExpect(jsonPath("$.averageLatencyMs").exists())
+        .andExpect(jsonPath("$.fallbackReasonCounts.LOW_CONFIDENCE").exists())
+        .andExpect(jsonPath("$.fallbackReasonCounts.COMPLEX_REQUEST").exists())
+        .andExpect(jsonPath("$.fallbackReasonCounts.EMOTION_HEAVY").exists());
+  }
+
+  @Test
+  void tracesEndpointShouldReturnRecentItems() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/dispatch")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                                {"sessionId":"t1","message":"계좌 확인하고 싶어요"}
+                                """))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(get("/api/dispatch/traces").param("limit", "1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].sessionId").value("t1"))
+        .andExpect(jsonPath("$[0].latencyMs").exists())
+        .andExpect(jsonPath("$[0].reason").exists());
   }
 }

--- a/docs/planning/exec-plans/active/finance-voiceops-mvp.md
+++ b/docs/planning/exec-plans/active/finance-voiceops-mvp.md
@@ -95,3 +95,5 @@ FlowMind Finance VoiceOps MVP 구현 계획
   - `FLOWMIND_CONFIDENCE_THRESHOLD` 설정 기반 confidence gate 적용
   - fallback reason 코드 분리(`LOW_CONFIDENCE`, `COMPLEX_REQUEST`, `EMOTION_HEAVY`)
   - dispatch trace에 `latencyMs` 필드 추가
+  - metrics에 fallback reason별 카운트 포함
+  - 운영 디버깅용 `GET /api/dispatch/traces?limit=N` 추가


### PR DESCRIPTION
## 변경 내용
- dispatch metrics에 fallback reason별 카운트(LOW_CONFIDENCE, COMPLEX_REQUEST, EMOTION_HEAVY) 추가
- 운영 디버깅용 최근 trace 조회 API 추가: GET /api/dispatch/traces?limit=N
- telemetry service에 recent trace 조회 로직 추가
- 컨트롤러 테스트 보강(metrics reason counts + traces endpoint)
- README/exec-plan 문서 업데이트

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
- backend/src/main/java/com/flowmind/dispatch/service/DispatchService.java
- backend/src/main/java/com/flowmind/dispatch/DispatchController.java
- backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
- backend/README.md
- docs/planning/exec-plans/active/finance-voiceops-mvp.md

## 핸드오프: 검증 결과
- spotlessCheck/test 통과
- metrics/traces API 테스트 통과

## 핸드오프: 남은 리스크
- trace 저장이 메모리 기반이라 장기 운영에서는 영속화(DB/로그 파이프라인) 필요

## 관련 이슈
- closes #15