### PR TITLE
feat: add traces limit guardrail

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -40,3 +40,5 @@ Invoke-WebRequest http://localhost:8080/swagger-ui.html
 - `FLOWMIND_CONFIDENCE_THRESHOLD` (default: `0.65`)
 
 The bootstrap defaults are set to start without requiring a live database connection.
+
+`/api/dispatch/traces` limit은 1~100 범위로 안전 보정된다.

--- a/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
+++ b/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class DispatchTelemetryService {
+  private static final int MAX_TRACE_LIMIT = 100;
 
   private final List<DispatchTrace> traces = new ArrayList<>();
   private final List<ConversationLogEntry> conversations = new ArrayList<>();
@@ -64,7 +65,7 @@ public class DispatchTelemetryService {
   }
 
   public synchronized List<DispatchTrace> recentTraces(int limit) {
-    int safeLimit = Math.max(limit, 1);
+    int safeLimit = Math.min(Math.max(limit, 1), MAX_TRACE_LIMIT);
     int fromIndex = Math.max(traces.size() - safeLimit, 0);
     return new ArrayList<>(traces.subList(fromIndex, traces.size()));
   }

--- a/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
+++ b/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
@@ -136,4 +136,24 @@ class DispatchControllerTest {
         .andExpect(jsonPath("$[0].latencyMs").exists())
         .andExpect(jsonPath("$[0].reason").exists());
   }
+
+  @Test
+  void tracesEndpointShouldHandleInvalidAndLargeLimitSafely() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/dispatch")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                                {"sessionId":"t2","message":"아무튼 뭔가 좀 해줘"}
+                                """))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(get("/api/dispatch/traces").param("limit", "0"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].sessionId").exists());
+
+    mockMvc.perform(get("/api/dispatch/traces").param("limit", "9999")).andExpect(status().isOk());
+  }
 }

--- a/docs/planning/exec-plans/active/finance-voiceops-mvp.md
+++ b/docs/planning/exec-plans/active/finance-voiceops-mvp.md
@@ -97,3 +97,4 @@ FlowMind Finance VoiceOps MVP 구현 계획
   - dispatch trace에 `latencyMs` 필드 추가
   - metrics에 fallback reason별 카운트 포함
   - 운영 디버깅용 `GET /api/dispatch/traces?limit=N` 추가
+  - traces 조회 limit 가드레일 적용(1~100 범위 보정)


### PR DESCRIPTION
## 변경 내용
- GET /api/dispatch/traces limit 가드레일 추가 (1~100 범위 보정)
- limit 0/과대 입력 시 안정 응답 테스트 추가
- 운영 문서/exec-plan에 limit 정책 반영

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
- backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
- backend/README.md
- docs/planning/exec-plans/active/finance-voiceops-mvp.md

## 핸드오프: 검증 결과
- traces limit 경계 입력 테스트 통과
- spotlessCheck/test 통과

## 핸드오프: 남은 리스크
- trace 저장은 메모리 기반으로, 다중 인스턴스 환경 집계 일관성은 추가 설계 필요

## 관련 이슈
- closes #17