### PR TITLE
feat: add fallback reason rate metrics

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -42,3 +42,4 @@ Invoke-WebRequest http://localhost:8080/swagger-ui.html
 The bootstrap defaults are set to start without requiring a live database connection.
 
 `/api/dispatch/traces` limit은 1~100 범위로 안전 보정된다.
+`/api/dispatch/metrics`는 `fallbackReasonCounts`와 `fallbackReasonRates`를 함께 제공한다.

--- a/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
+++ b/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
@@ -61,7 +61,12 @@ public class DispatchTelemetryService {
         totalCount == 0 ? 0.0 : (double) lowConfidence.get() / totalCount;
     double avgLatency = totalCount == 0 ? 0.0 : (double) latencyTotalMs / totalCount;
     return new MetricsSnapshot(
-        totalCount, fallbackRate, misclassificationRate, avgLatency, fallbackReasonSnapshot());
+        totalCount,
+        fallbackRate,
+        misclassificationRate,
+        avgLatency,
+        fallbackReasonSnapshot(),
+        fallbackReasonRateSnapshot());
   }
 
   public synchronized List<DispatchTrace> recentTraces(int limit) {
@@ -78,10 +83,22 @@ public class DispatchTelemetryService {
     return snapshot;
   }
 
+  private Map<String, Double> fallbackReasonRateSnapshot() {
+    Map<String, Double> snapshot = new java.util.LinkedHashMap<>();
+    int totalCount = total.get();
+    for (FallbackReason reason : FallbackReason.values()) {
+      double rate =
+          totalCount == 0 ? 0.0 : (double) fallbackReasonCounts.get(reason).get() / totalCount;
+      snapshot.put(reason.name(), rate);
+    }
+    return snapshot;
+  }
+
   public record MetricsSnapshot(
       int totalRequests,
       double fallbackRate,
       double misclassificationRate,
       double averageLatencyMs,
-      Map<String, Integer> fallbackReasonCounts) {}
+      Map<String, Integer> fallbackReasonCounts,
+      Map<String, Double> fallbackReasonRates) {}
 }

--- a/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
+++ b/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
@@ -114,7 +114,10 @@ class DispatchControllerTest {
         .andExpect(jsonPath("$.averageLatencyMs").exists())
         .andExpect(jsonPath("$.fallbackReasonCounts.LOW_CONFIDENCE").exists())
         .andExpect(jsonPath("$.fallbackReasonCounts.COMPLEX_REQUEST").exists())
-        .andExpect(jsonPath("$.fallbackReasonCounts.EMOTION_HEAVY").exists());
+        .andExpect(jsonPath("$.fallbackReasonCounts.EMOTION_HEAVY").exists())
+        .andExpect(jsonPath("$.fallbackReasonRates.LOW_CONFIDENCE").exists())
+        .andExpect(jsonPath("$.fallbackReasonRates.COMPLEX_REQUEST").exists())
+        .andExpect(jsonPath("$.fallbackReasonRates.EMOTION_HEAVY").exists());
   }
 
   @Test


### PR DESCRIPTION
## 변경 내용
- /api/dispatch/metrics 응답에 allbackReasonRates 필드 추가
- total=0 상황에서 reason rate를 0.0으로 안전 처리
- metrics API 테스트에 reason rates 검증 추가
- README 업데이트

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
- backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
- backend/README.md

## 핸드오프: 검증 결과
- metrics response에 fallbackReasonRates 노출 확인
- spotlessCheck/test 통과

## 핸드오프: 남은 리스크
- rate 기준 분모를 전체 요청으로 두고 있어, 필요 시 LLM fallback 요청 기준 비율 필드 추가 검토 필요

## 관련 이슈
- closes #19