### PR TITLE
feat: add metrics recent window trend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -43,3 +43,4 @@ The bootstrap defaults are set to start without requiring a live database connec
 
 `/api/dispatch/traces` limit은 1~100 범위로 안전 보정된다.
 `/api/dispatch/metrics`는 `fallbackReasonCounts`와 `fallbackReasonRates`를 함께 제공한다.
+`/api/dispatch/metrics?window=N`은 최근 N요청 추세 지표를 제공하며 N은 1~200으로 보정된다.

--- a/backend/src/main/java/com/flowmind/dispatch/DispatchController.java
+++ b/backend/src/main/java/com/flowmind/dispatch/DispatchController.java
@@ -30,8 +30,9 @@ public class DispatchController {
   }
 
   @GetMapping("/metrics")
-  public ResponseEntity<DispatchTelemetryService.MetricsSnapshot> metrics() {
-    return ResponseEntity.ok(dispatchService.metrics());
+  public ResponseEntity<DispatchTelemetryService.MetricsSnapshot> metrics(
+      @RequestParam(defaultValue = "50") int window) {
+    return ResponseEntity.ok(dispatchService.metrics(window));
   }
 
   @GetMapping("/traces")

--- a/backend/src/main/java/com/flowmind/dispatch/service/DispatchService.java
+++ b/backend/src/main/java/com/flowmind/dispatch/service/DispatchService.java
@@ -106,8 +106,8 @@ public class DispatchService {
     return response;
   }
 
-  public DispatchTelemetryService.MetricsSnapshot metrics() {
-    return telemetryService.snapshot();
+  public DispatchTelemetryService.MetricsSnapshot metrics(int window) {
+    return telemetryService.snapshot(window);
   }
 
   public List<DispatchTrace> recentTraces(int limit) {

--- a/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
+++ b/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class DispatchTelemetryService {
   private static final int MAX_TRACE_LIMIT = 100;
+  private static final int DEFAULT_METRICS_WINDOW = 50;
+  private static final int MAX_METRICS_WINDOW = 200;
 
   private final List<DispatchTrace> traces = new ArrayList<>();
   private final List<ConversationLogEntry> conversations = new ArrayList<>();
@@ -54,19 +56,34 @@ public class DispatchTelemetryService {
     }
   }
 
-  public synchronized MetricsSnapshot snapshot() {
+  public synchronized MetricsSnapshot snapshot(int window) {
     int totalCount = total.get();
     double fallbackRate = totalCount == 0 ? 0.0 : (double) fallback.get() / totalCount;
     double misclassificationRate =
         totalCount == 0 ? 0.0 : (double) lowConfidence.get() / totalCount;
     double avgLatency = totalCount == 0 ? 0.0 : (double) latencyTotalMs / totalCount;
+
+    int safeWindow = Math.min(Math.max(window, 1), MAX_METRICS_WINDOW);
+    int recentFrom = Math.max(traces.size() - safeWindow, 0);
+    List<DispatchTrace> recent = traces.subList(recentFrom, traces.size());
+    Map<String, Integer> recentCounts = recentFallbackReasonSnapshot(recent);
+    Map<String, Double> recentRates = recentFallbackReasonRateSnapshot(recentCounts, recent.size());
+
     return new MetricsSnapshot(
         totalCount,
         fallbackRate,
         misclassificationRate,
         avgLatency,
         fallbackReasonSnapshot(),
-        fallbackReasonRateSnapshot());
+        fallbackReasonRateSnapshot(),
+        safeWindow,
+        recent.size(),
+        recentCounts,
+        recentRates);
+  }
+
+  public synchronized MetricsSnapshot snapshot() {
+    return snapshot(DEFAULT_METRICS_WINDOW);
   }
 
   public synchronized List<DispatchTrace> recentTraces(int limit) {
@@ -94,11 +111,41 @@ public class DispatchTelemetryService {
     return snapshot;
   }
 
+  private Map<String, Integer> recentFallbackReasonSnapshot(List<DispatchTrace> recent) {
+    Map<String, Integer> snapshot = new java.util.LinkedHashMap<>();
+    for (FallbackReason reason : FallbackReason.values()) {
+      snapshot.put(reason.name(), 0);
+    }
+    for (DispatchTrace trace : recent) {
+      for (FallbackReason reason : FallbackReason.values()) {
+        if (reason.name().equals(trace.reason())) {
+          snapshot.put(reason.name(), snapshot.get(reason.name()) + 1);
+        }
+      }
+    }
+    return snapshot;
+  }
+
+  private Map<String, Double> recentFallbackReasonRateSnapshot(
+      Map<String, Integer> recentCounts, int recentSize) {
+    Map<String, Double> snapshot = new java.util.LinkedHashMap<>();
+    for (FallbackReason reason : FallbackReason.values()) {
+      int count = recentCounts.get(reason.name());
+      double rate = recentSize == 0 ? 0.0 : (double) count / recentSize;
+      snapshot.put(reason.name(), rate);
+    }
+    return snapshot;
+  }
+
   public record MetricsSnapshot(
       int totalRequests,
       double fallbackRate,
       double misclassificationRate,
       double averageLatencyMs,
       Map<String, Integer> fallbackReasonCounts,
-      Map<String, Double> fallbackReasonRates) {}
+      Map<String, Double> fallbackReasonRates,
+      int metricsWindow,
+      int recentRequestCount,
+      Map<String, Integer> recentFallbackReasonCounts,
+      Map<String, Double> recentFallbackReasonRates) {}
 }

--- a/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
+++ b/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
@@ -107,7 +107,7 @@ class DispatchControllerTest {
         .andExpect(status().isOk());
 
     mockMvc
-        .perform(get("/api/dispatch/metrics"))
+        .perform(get("/api/dispatch/metrics").param("window", "50"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.totalRequests").exists())
         .andExpect(jsonPath("$.fallbackRate").exists())
@@ -117,7 +117,11 @@ class DispatchControllerTest {
         .andExpect(jsonPath("$.fallbackReasonCounts.EMOTION_HEAVY").exists())
         .andExpect(jsonPath("$.fallbackReasonRates.LOW_CONFIDENCE").exists())
         .andExpect(jsonPath("$.fallbackReasonRates.COMPLEX_REQUEST").exists())
-        .andExpect(jsonPath("$.fallbackReasonRates.EMOTION_HEAVY").exists());
+        .andExpect(jsonPath("$.fallbackReasonRates.EMOTION_HEAVY").exists())
+        .andExpect(jsonPath("$.metricsWindow").value(50))
+        .andExpect(jsonPath("$.recentRequestCount").exists())
+        .andExpect(jsonPath("$.recentFallbackReasonCounts.LOW_CONFIDENCE").exists())
+        .andExpect(jsonPath("$.recentFallbackReasonRates.LOW_CONFIDENCE").exists());
   }
 
   @Test
@@ -158,5 +162,18 @@ class DispatchControllerTest {
         .andExpect(jsonPath("$[0].sessionId").exists());
 
     mockMvc.perform(get("/api/dispatch/traces").param("limit", "9999")).andExpect(status().isOk());
+  }
+
+  @Test
+  void metricsEndpointShouldHandleInvalidAndLargeWindowSafely() throws Exception {
+    mockMvc
+        .perform(get("/api/dispatch/metrics").param("window", "0"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.metricsWindow").value(1));
+
+    mockMvc
+        .perform(get("/api/dispatch/metrics").param("window", "9999"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.metricsWindow").value(200));
   }
 }


### PR DESCRIPTION
## 변경 내용
- /api/dispatch/metrics?window=N 지원 추가
- window를 1~200 범위로 보정
- metrics 응답에 최근 구간 지표 추가
  - metricsWindow
  - ecentRequestCount
  - ecentFallbackReasonCounts
  - ecentFallbackReasonRates
- 테스트/README 업데이트

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/dispatch/DispatchController.java
- backend/src/main/java/com/flowmind/dispatch/service/DispatchService.java
- backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
- backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
- backend/README.md

## 핸드오프: 검증 결과
- metrics window 경계값 테스트 통과
- spotlessCheck/test 통과

## 핸드오프: 남은 리스크
- 최근 구간은 in-memory trace 기준이며 재시작 시 초기화됨

## 관련 이슈
- closes #21