### PR TITLE
feat: add fallback-within-fallback rates

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -42,5 +42,5 @@ Invoke-WebRequest http://localhost:8080/swagger-ui.html
 The bootstrap defaults are set to start without requiring a live database connection.
 
 `/api/dispatch/traces` limit은 1~100 범위로 안전 보정된다.
-`/api/dispatch/metrics`는 `fallbackReasonCounts`와 `fallbackReasonRates`를 함께 제공한다.
+`/api/dispatch/metrics`는 `fallbackReasonCounts`, `fallbackReasonRates`, `fallbackReasonRatesWithinFallback`를 함께 제공한다.
 `/api/dispatch/metrics?window=N`은 최근 N요청 추세 지표를 제공하며 N은 1~200으로 보정된다.

--- a/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
+++ b/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
@@ -68,6 +68,8 @@ public class DispatchTelemetryService {
     List<DispatchTrace> recent = traces.subList(recentFrom, traces.size());
     Map<String, Integer> recentCounts = recentFallbackReasonSnapshot(recent);
     Map<String, Double> recentRates = recentFallbackReasonRateSnapshot(recentCounts, recent.size());
+    Map<String, Double> recentRatesWithinFallback =
+        recentFallbackReasonRateWithinFallbackSnapshot(recentCounts);
 
     return new MetricsSnapshot(
         totalCount,
@@ -76,10 +78,12 @@ public class DispatchTelemetryService {
         avgLatency,
         fallbackReasonSnapshot(),
         fallbackReasonRateSnapshot(),
+        fallbackReasonRateWithinFallbackSnapshot(),
         safeWindow,
         recent.size(),
         recentCounts,
-        recentRates);
+        recentRates,
+        recentRatesWithinFallback);
   }
 
   public synchronized MetricsSnapshot snapshot() {
@@ -111,6 +115,19 @@ public class DispatchTelemetryService {
     return snapshot;
   }
 
+  private Map<String, Double> fallbackReasonRateWithinFallbackSnapshot() {
+    Map<String, Double> snapshot = new java.util.LinkedHashMap<>();
+    int fallbackCount = fallback.get();
+    for (FallbackReason reason : FallbackReason.values()) {
+      double rate =
+          fallbackCount == 0
+              ? 0.0
+              : (double) fallbackReasonCounts.get(reason).get() / fallbackCount;
+      snapshot.put(reason.name(), rate);
+    }
+    return snapshot;
+  }
+
   private Map<String, Integer> recentFallbackReasonSnapshot(List<DispatchTrace> recent) {
     Map<String, Integer> snapshot = new java.util.LinkedHashMap<>();
     for (FallbackReason reason : FallbackReason.values()) {
@@ -137,6 +154,18 @@ public class DispatchTelemetryService {
     return snapshot;
   }
 
+  private Map<String, Double> recentFallbackReasonRateWithinFallbackSnapshot(
+      Map<String, Integer> recentCounts) {
+    Map<String, Double> snapshot = new java.util.LinkedHashMap<>();
+    int fallbackCount = recentCounts.values().stream().mapToInt(Integer::intValue).sum();
+    for (FallbackReason reason : FallbackReason.values()) {
+      int count = recentCounts.get(reason.name());
+      double rate = fallbackCount == 0 ? 0.0 : (double) count / fallbackCount;
+      snapshot.put(reason.name(), rate);
+    }
+    return snapshot;
+  }
+
   public record MetricsSnapshot(
       int totalRequests,
       double fallbackRate,
@@ -144,8 +173,10 @@ public class DispatchTelemetryService {
       double averageLatencyMs,
       Map<String, Integer> fallbackReasonCounts,
       Map<String, Double> fallbackReasonRates,
+      Map<String, Double> fallbackReasonRatesWithinFallback,
       int metricsWindow,
       int recentRequestCount,
       Map<String, Integer> recentFallbackReasonCounts,
-      Map<String, Double> recentFallbackReasonRates) {}
+      Map<String, Double> recentFallbackReasonRates,
+      Map<String, Double> recentFallbackReasonRatesWithinFallback) {}
 }

--- a/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
+++ b/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
@@ -118,10 +118,14 @@ class DispatchControllerTest {
         .andExpect(jsonPath("$.fallbackReasonRates.LOW_CONFIDENCE").exists())
         .andExpect(jsonPath("$.fallbackReasonRates.COMPLEX_REQUEST").exists())
         .andExpect(jsonPath("$.fallbackReasonRates.EMOTION_HEAVY").exists())
+        .andExpect(jsonPath("$.fallbackReasonRatesWithinFallback.LOW_CONFIDENCE").exists())
+        .andExpect(jsonPath("$.fallbackReasonRatesWithinFallback.COMPLEX_REQUEST").exists())
+        .andExpect(jsonPath("$.fallbackReasonRatesWithinFallback.EMOTION_HEAVY").exists())
         .andExpect(jsonPath("$.metricsWindow").value(50))
         .andExpect(jsonPath("$.recentRequestCount").exists())
         .andExpect(jsonPath("$.recentFallbackReasonCounts.LOW_CONFIDENCE").exists())
-        .andExpect(jsonPath("$.recentFallbackReasonRates.LOW_CONFIDENCE").exists());
+        .andExpect(jsonPath("$.recentFallbackReasonRates.LOW_CONFIDENCE").exists())
+        .andExpect(jsonPath("$.recentFallbackReasonRatesWithinFallback.LOW_CONFIDENCE").exists());
   }
 
   @Test


### PR DESCRIPTION
## 변경 내용
- metrics 응답에 fallback 내부 분모 비율 추가
  - allbackReasonRatesWithinFallback
  - ecentFallbackReasonRatesWithinFallback
- fallback 0건일 때 0.0 안전 처리
- 테스트/README 업데이트

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
- backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
- backend/README.md

## 핸드오프: 검증 결과
- metrics 응답 신규 필드 노출 확인
- spotlessCheck/test 통과

## 핸드오프: 남은 리스크
- 현재 지표는 메모리 기반 누적/윈도우 계산으로 인스턴스 재시작 시 리셋됨

## 관련 이슈
- closes #23