### PR TITLE
feat: add recent fallback summary metrics

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -44,3 +44,4 @@ The bootstrap defaults are set to start without requiring a live database connec
 `/api/dispatch/traces` limit은 1~100 범위로 안전 보정된다.
 `/api/dispatch/metrics`는 `fallbackReasonCounts`, `fallbackReasonRates`, `fallbackReasonRatesWithinFallback`를 함께 제공한다.
 `/api/dispatch/metrics?window=N`은 최근 N요청 추세 지표를 제공하며 N은 1~200으로 보정된다.
+최근 구간 요약으로 `recentFallbackCount`, `recentFallbackRate`도 함께 제공된다.

--- a/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
+++ b/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
@@ -66,6 +66,10 @@ public class DispatchTelemetryService {
     int safeWindow = Math.min(Math.max(window, 1), MAX_METRICS_WINDOW);
     int recentFrom = Math.max(traces.size() - safeWindow, 0);
     List<DispatchTrace> recent = traces.subList(recentFrom, traces.size());
+    int recentFallbackCount =
+        (int) recent.stream().filter(trace -> trace.route() == RouteType.LLM).count();
+    double recentFallbackRate =
+        recent.isEmpty() ? 0.0 : (double) recentFallbackCount / recent.size();
     Map<String, Integer> recentCounts = recentFallbackReasonSnapshot(recent);
     Map<String, Double> recentRates = recentFallbackReasonRateSnapshot(recentCounts, recent.size());
     Map<String, Double> recentRatesWithinFallback =
@@ -81,6 +85,8 @@ public class DispatchTelemetryService {
         fallbackReasonRateWithinFallbackSnapshot(),
         safeWindow,
         recent.size(),
+        recentFallbackCount,
+        recentFallbackRate,
         recentCounts,
         recentRates,
         recentRatesWithinFallback);
@@ -176,6 +182,8 @@ public class DispatchTelemetryService {
       Map<String, Double> fallbackReasonRatesWithinFallback,
       int metricsWindow,
       int recentRequestCount,
+      int recentFallbackCount,
+      double recentFallbackRate,
       Map<String, Integer> recentFallbackReasonCounts,
       Map<String, Double> recentFallbackReasonRates,
       Map<String, Double> recentFallbackReasonRatesWithinFallback) {}

--- a/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
+++ b/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
@@ -123,6 +123,8 @@ class DispatchControllerTest {
         .andExpect(jsonPath("$.fallbackReasonRatesWithinFallback.EMOTION_HEAVY").exists())
         .andExpect(jsonPath("$.metricsWindow").value(50))
         .andExpect(jsonPath("$.recentRequestCount").exists())
+        .andExpect(jsonPath("$.recentFallbackCount").exists())
+        .andExpect(jsonPath("$.recentFallbackRate").exists())
         .andExpect(jsonPath("$.recentFallbackReasonCounts.LOW_CONFIDENCE").exists())
         .andExpect(jsonPath("$.recentFallbackReasonRates.LOW_CONFIDENCE").exists())
         .andExpect(jsonPath("$.recentFallbackReasonRatesWithinFallback.LOW_CONFIDENCE").exists());


### PR DESCRIPTION
## 변경 내용
- metrics 응답에 최근 구간 fallback 요약 필드 추가
  - ecentFallbackCount
  - ecentFallbackRate
- recent request 0건일 때 rate 0.0 처리
- 테스트/README 업데이트

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
- backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
- backend/README.md

## 핸드오프: 검증 결과
- metrics 응답에 recentFallbackCount/recentFallbackRate 확인
- spotlessCheck/test 통과

## 핸드오프: 남은 리스크
- 최근 구간 계산은 메모리 trace 기반으로 서비스 재시작 시 초기화됨

## 관련 이슈
- closes #25