### PR TITLE
feat: add recent fallback latency metric

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -44,4 +44,4 @@ The bootstrap defaults are set to start without requiring a live database connec
 `/api/dispatch/traces` limit은 1~100 범위로 안전 보정된다.
 `/api/dispatch/metrics`는 `fallbackReasonCounts`, `fallbackReasonRates`, `fallbackReasonRatesWithinFallback`를 함께 제공한다.
 `/api/dispatch/metrics?window=N`은 최근 N요청 추세 지표를 제공하며 N은 1~200으로 보정된다.
-최근 구간 요약으로 `recentFallbackCount`, `recentFallbackRate`도 함께 제공된다.
+최근 구간 요약으로 `recentFallbackCount`, `recentFallbackRate`, `recentFallbackLatencyAvgMs`도 함께 제공된다.

--- a/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
+++ b/backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
@@ -70,6 +70,14 @@ public class DispatchTelemetryService {
         (int) recent.stream().filter(trace -> trace.route() == RouteType.LLM).count();
     double recentFallbackRate =
         recent.isEmpty() ? 0.0 : (double) recentFallbackCount / recent.size();
+    double recentFallbackLatencyAvgMs =
+        recentFallbackCount == 0
+            ? 0.0
+            : recent.stream()
+                .filter(trace -> trace.route() == RouteType.LLM)
+                .mapToLong(trace -> trace.latencyMs() == null ? 0L : trace.latencyMs())
+                .average()
+                .orElse(0.0);
     Map<String, Integer> recentCounts = recentFallbackReasonSnapshot(recent);
     Map<String, Double> recentRates = recentFallbackReasonRateSnapshot(recentCounts, recent.size());
     Map<String, Double> recentRatesWithinFallback =
@@ -87,6 +95,7 @@ public class DispatchTelemetryService {
         recent.size(),
         recentFallbackCount,
         recentFallbackRate,
+        recentFallbackLatencyAvgMs,
         recentCounts,
         recentRates,
         recentRatesWithinFallback);
@@ -184,6 +193,7 @@ public class DispatchTelemetryService {
       int recentRequestCount,
       int recentFallbackCount,
       double recentFallbackRate,
+      double recentFallbackLatencyAvgMs,
       Map<String, Integer> recentFallbackReasonCounts,
       Map<String, Double> recentFallbackReasonRates,
       Map<String, Double> recentFallbackReasonRatesWithinFallback) {}

--- a/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
+++ b/backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
@@ -125,6 +125,7 @@ class DispatchControllerTest {
         .andExpect(jsonPath("$.recentRequestCount").exists())
         .andExpect(jsonPath("$.recentFallbackCount").exists())
         .andExpect(jsonPath("$.recentFallbackRate").exists())
+        .andExpect(jsonPath("$.recentFallbackLatencyAvgMs").exists())
         .andExpect(jsonPath("$.recentFallbackReasonCounts.LOW_CONFIDENCE").exists())
         .andExpect(jsonPath("$.recentFallbackReasonRates.LOW_CONFIDENCE").exists())
         .andExpect(jsonPath("$.recentFallbackReasonRatesWithinFallback.LOW_CONFIDENCE").exists());


### PR DESCRIPTION
## 변경 내용
- metrics 응답에 ecentFallbackLatencyAvgMs 필드 추가
- 최근 window에서 fallback(route=LLM)만 대상으로 평균 지연 계산
- recent fallback 0건일 때 0.0 처리
- 테스트/README 업데이트

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/dispatch/service/DispatchTelemetryService.java
- backend/src/test/java/com/flowmind/dispatch/DispatchControllerTest.java
- backend/README.md

## 핸드오프: 검증 결과
- metrics 응답 신규 필드(ecentFallbackLatencyAvgMs) 확인
- spotlessCheck/test 통과

## 핸드오프: 남은 리스크
- 지표 계산은 메모리 trace 기반이라 재시작 시 window 데이터 초기화

## 관련 이슈
- closes #27