### PR TITLE
feat: add spring ai ollama local chat endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -14,6 +14,21 @@ cd backend
 .\gradlew.bat bootRun
 ```
 
+## Run (Free Local AI Stack)
+
+```powershell
+# repo root
+docker compose -f docker-compose.local-ai.yml up -d
+
+# 모델 다운로드(최초 1회)
+docker exec -it flowmind-ollama ollama pull qwen2.5:7b
+docker exec -it flowmind-ollama ollama pull nomic-embed-text
+
+# backend 실행
+cd backend
+.\gradlew.bat bootRun --args="--spring.profiles.active=local"
+```
+
 ## Verify
 
 ```powershell
@@ -21,6 +36,7 @@ Invoke-WebRequest http://localhost:8080/api/health
 Invoke-WebRequest http://localhost:8080/actuator/health
 Invoke-WebRequest http://localhost:8080/api/dispatch/metrics
 Invoke-WebRequest "http://localhost:8080/api/dispatch/traces?limit=10"
+Invoke-WebRequest http://localhost:8080/api/ai/chat -Method Post -ContentType "application/json" -Body '{"message":"안녕하세요"}'
 Invoke-WebRequest http://localhost:8080/swagger-ui.html
 .\gradlew.bat test
 .\\gradlew.bat spotlessCheck
@@ -38,6 +54,9 @@ Invoke-WebRequest http://localhost:8080/swagger-ui.html
 - `FLOWMIND_OPENAI_ENABLED`
 - `FLOWMIND_SWAGGER_ENABLED`
 - `FLOWMIND_CONFIDENCE_THRESHOLD` (default: `0.65`)
+- `FLOWMIND_OLLAMA_BASE_URL` (default: `http://localhost:11434`)
+- `FLOWMIND_OLLAMA_CHAT_MODEL` (default: `qwen2.5:7b`)
+- `FLOWMIND_OLLAMA_EMBEDDING_MODEL` (default: `nomic-embed-text`)
 
 The bootstrap defaults are set to start without requiring a live database connection.
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -18,6 +18,12 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.ai:spring-ai-bom:1.0.0")
+    }
+}
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -25,6 +31,7 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
+    implementation("org.springframework.ai:spring-ai-starter-model-ollama")
     runtimeOnly("org.postgresql:postgresql")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/backend/src/main/java/com/flowmind/ai/AiChatController.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatController.java
@@ -1,0 +1,35 @@
+package com.flowmind.ai;
+
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/ai")
+public class AiChatController {
+
+  private final AiChatService aiChatService;
+
+  public AiChatController(AiChatService aiChatService) {
+    this.aiChatService = aiChatService;
+  }
+
+  @PostMapping("/chat")
+  public ResponseEntity<?> chat(@RequestBody AiChatRequest request) {
+    String message = request == null ? null : request.message();
+    if (message == null || message.isBlank()) {
+      return ResponseEntity.badRequest().body(Map.of("error", "message is required"));
+    }
+
+    try {
+      String answer = aiChatService.chat(message);
+      return ResponseEntity.ok(new AiChatResponse(answer, "ollama"));
+    } catch (RuntimeException ex) {
+      return ResponseEntity.status(503)
+          .body(Map.of("error", "llm_unavailable", "detail", ex.getMessage()));
+    }
+  }
+}

--- a/backend/src/main/java/com/flowmind/ai/AiChatRequest.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatRequest.java
@@ -1,0 +1,3 @@
+package com.flowmind.ai;
+
+public record AiChatRequest(String message) {}

--- a/backend/src/main/java/com/flowmind/ai/AiChatResponse.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatResponse.java
@@ -1,0 +1,3 @@
+package com.flowmind.ai;
+
+public record AiChatResponse(String answer, String provider) {}

--- a/backend/src/main/java/com/flowmind/ai/AiChatService.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatService.java
@@ -1,0 +1,18 @@
+package com.flowmind.ai;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AiChatService {
+
+  private final ChatClient chatClient;
+
+  public AiChatService(ChatClient.Builder chatClientBuilder) {
+    this.chatClient = chatClientBuilder.build();
+  }
+
+  public String chat(String message) {
+    return chatClient.prompt().user(message).call().content();
+  }
+}

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,0 +1,26 @@
+spring:
+  datasource:
+    url: ${FLOWMIND_DB_URL:jdbc:postgresql://localhost:5432/flowmind}
+    username: ${FLOWMIND_DB_USERNAME:flowmind}
+    password: ${FLOWMIND_DB_PASSWORD:flowmind}
+  flyway:
+    enabled: ${FLOWMIND_FLYWAY_ENABLED:true}
+
+  ai:
+    ollama:
+      base-url: ${FLOWMIND_OLLAMA_BASE_URL:http://localhost:11434}
+      chat:
+        options:
+          model: ${FLOWMIND_OLLAMA_CHAT_MODEL:qwen2.5:7b}
+      embedding:
+        options:
+          model: ${FLOWMIND_OLLAMA_EMBEDDING_MODEL:nomic-embed-text}
+
+flowmind:
+  integration:
+    openai-enabled: false
+    redis-enabled: false
+  storage:
+    database-enabled: true
+    flyway-enabled: true
+

--- a/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
+++ b/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
@@ -1,0 +1,52 @@
+package com.flowmind.ai;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AiChatControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private AiChatService aiChatService;
+
+  @Test
+  void shouldReturnBadRequestWhenMessageIsBlank() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/ai/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"message":" "}
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value("message is required"));
+  }
+
+  @Test
+  void shouldReturnAiAnswer() throws Exception {
+    when(aiChatService.chat("안녕")).thenReturn("안녕하세요.");
+
+    mockMvc
+        .perform(
+            post("/api/ai/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"message":"안녕"}
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.provider").value("ollama"))
+        .andExpect(jsonPath("$.answer").value("안녕하세요."));
+  }
+}

--- a/docker-compose.local-ai.yml
+++ b/docker-compose.local-ai.yml
@@ -1,0 +1,30 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: flowmind-postgres
+    environment:
+      POSTGRES_DB: flowmind
+      POSTGRES_USER: flowmind
+      POSTGRES_PASSWORD: flowmind
+    ports:
+      - "5432:5432"
+    volumes:
+      - flowmind-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U flowmind -d flowmind"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  ollama:
+    image: ollama/ollama:latest
+    container_name: flowmind-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - flowmind-ollama-data:/root/.ollama
+
+volumes:
+  flowmind-postgres-data:
+  flowmind-ollama-data:
+


### PR DESCRIPTION
## 변경 내용
- Spring AI(Ollama) 의존성 추가
- 로컬 프로필(pplication-local.yml) 추가
- 무료 로컬 인프라용 docker-compose.local-ai.yml 추가
- 최소 AI 채팅 엔드포인트 추가: POST /api/ai/chat
- AI 채팅 컨트롤러 테스트 추가
- backend README 실행/검증 가이드 업데이트

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/build.gradle.kts
- backend/src/main/resources/application-local.yml
- backend/src/main/java/com/flowmind/ai/AiChatController.java
- backend/src/main/java/com/flowmind/ai/AiChatService.java
- backend/src/main/java/com/flowmind/ai/AiChatRequest.java
- backend/src/main/java/com/flowmind/ai/AiChatResponse.java
- backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
- docker-compose.local-ai.yml
- backend/README.md

## 핸드오프: 검증 결과
- 포맷/테스트 통과
- /api/ai/chat 요청 유효성(빈 message) 및 정상 응답 테스트 통과

## 핸드오프: 남은 리스크
- 테스트에서 @MockBean 경고(향후 Spring Boot 최신 규약으로 교체 필요)
- 실제 LLM 응답 품질/지연은 로컬 모델 리소스(CPU/RAM/GPU)에 크게 의존

## 관련 이슈
- refs #27