### PR TITLE
feat: add latency metadata to ai chat response

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -64,3 +64,4 @@ The bootstrap defaults are set to start without requiring a live database connec
 `/api/dispatch/metrics`는 `fallbackReasonCounts`, `fallbackReasonRates`, `fallbackReasonRatesWithinFallback`를 함께 제공한다.
 `/api/dispatch/metrics?window=N`은 최근 N요청 추세 지표를 제공하며 N은 1~200으로 보정된다.
 최근 구간 요약으로 `recentFallbackCount`, `recentFallbackRate`, `recentFallbackLatencyAvgMs`도 함께 제공된다.
+`/api/ai/chat` 응답에는 `latencyMs`가 포함된다.

--- a/backend/src/main/java/com/flowmind/ai/AiChatController.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatController.java
@@ -1,5 +1,7 @@
 package com.flowmind.ai;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +21,7 @@ public class AiChatController {
 
   @PostMapping("/chat")
   public ResponseEntity<?> chat(@RequestBody AiChatRequest request) {
+    Instant start = Instant.now();
     String message = request == null ? null : request.message();
     if (message == null || message.isBlank()) {
       return ResponseEntity.badRequest().body(Map.of("error", "message is required"));
@@ -26,7 +29,8 @@ public class AiChatController {
 
     try {
       String answer = aiChatService.chat(message);
-      return ResponseEntity.ok(new AiChatResponse(answer, "ollama"));
+      long latencyMs = Duration.between(start, Instant.now()).toMillis();
+      return ResponseEntity.ok(new AiChatResponse(answer, "ollama", latencyMs));
     } catch (RuntimeException ex) {
       return ResponseEntity.status(503)
           .body(Map.of("error", "llm_unavailable", "detail", ex.getMessage()));

--- a/backend/src/main/java/com/flowmind/ai/AiChatResponse.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatResponse.java
@@ -1,3 +1,3 @@
 package com.flowmind.ai;
 
-public record AiChatResponse(String answer, String provider) {}
+public record AiChatResponse(String answer, String provider, long latencyMs) {}

--- a/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
+++ b/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
@@ -47,6 +47,7 @@ class AiChatControllerTest {
                     """))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.provider").value("ollama"))
-        .andExpect(jsonPath("$.answer").value("안녕하세요."));
+        .andExpect(jsonPath("$.answer").value("안녕하세요."))
+        .andExpect(jsonPath("$.latencyMs").exists());
   }
 }


### PR DESCRIPTION
## 변경 내용
- /api/ai/chat 정상 응답에 latencyMs 필드 추가
- 요청 시작~응답 생성까지 elapsed ms를 계산해 반환
- AI chat 테스트에 latencyMs 검증 추가
- README에 응답 메타 필드 설명 반영

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/ai/AiChatController.java
- backend/src/main/java/com/flowmind/ai/AiChatResponse.java
- backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
- backend/README.md

## 핸드오프: 검증 결과
- /api/ai/chat 응답의 latencyMs 필드 노출 확인
- spotlessCheck/test 통과

## 핸드오프: 남은 리스크
- 지연시간은 애플리케이션 레벨 측정값으로 네트워크/큐 지연은 별도 관측 지표 필요

## 관련 이슈
- closes #30