### PR TITLE
feat: add session id support to ai chat api

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -36,7 +36,7 @@ Invoke-WebRequest http://localhost:8080/api/health
 Invoke-WebRequest http://localhost:8080/actuator/health
 Invoke-WebRequest http://localhost:8080/api/dispatch/metrics
 Invoke-WebRequest "http://localhost:8080/api/dispatch/traces?limit=10"
-Invoke-WebRequest http://localhost:8080/api/ai/chat -Method Post -ContentType "application/json" -Body '{"message":"안녕하세요"}'
+Invoke-WebRequest http://localhost:8080/api/ai/chat -Method Post -ContentType "application/json" -Body '{"message":"안녕하세요","sessionId":"s-1"}'
 Invoke-WebRequest http://localhost:8080/swagger-ui.html
 .\gradlew.bat test
 .\\gradlew.bat spotlessCheck
@@ -64,4 +64,4 @@ The bootstrap defaults are set to start without requiring a live database connec
 `/api/dispatch/metrics`는 `fallbackReasonCounts`, `fallbackReasonRates`, `fallbackReasonRatesWithinFallback`를 함께 제공한다.
 `/api/dispatch/metrics?window=N`은 최근 N요청 추세 지표를 제공하며 N은 1~200으로 보정된다.
 최근 구간 요약으로 `recentFallbackCount`, `recentFallbackRate`, `recentFallbackLatencyAvgMs`도 함께 제공된다.
-`/api/ai/chat` 응답에는 `latencyMs`가 포함된다.
+`/api/ai/chat` 응답에는 `latencyMs`, `sessionId`가 포함된다.

--- a/backend/src/main/java/com/flowmind/ai/AiChatController.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatController.java
@@ -23,6 +23,7 @@ public class AiChatController {
   public ResponseEntity<?> chat(@RequestBody AiChatRequest request) {
     Instant start = Instant.now();
     String message = request == null ? null : request.message();
+    String sessionId = request == null ? null : request.sessionId();
     if (message == null || message.isBlank()) {
       return ResponseEntity.badRequest().body(Map.of("error", "message is required"));
     }
@@ -30,7 +31,7 @@ public class AiChatController {
     try {
       String answer = aiChatService.chat(message);
       long latencyMs = Duration.between(start, Instant.now()).toMillis();
-      return ResponseEntity.ok(new AiChatResponse(answer, "ollama", latencyMs));
+      return ResponseEntity.ok(new AiChatResponse(answer, "ollama", latencyMs, sessionId));
     } catch (RuntimeException ex) {
       return ResponseEntity.status(503)
           .body(Map.of("error", "llm_unavailable", "detail", ex.getMessage()));

--- a/backend/src/main/java/com/flowmind/ai/AiChatRequest.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatRequest.java
@@ -1,3 +1,3 @@
 package com.flowmind.ai;
 
-public record AiChatRequest(String message) {}
+public record AiChatRequest(String message, String sessionId) {}

--- a/backend/src/main/java/com/flowmind/ai/AiChatResponse.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatResponse.java
@@ -1,3 +1,3 @@
 package com.flowmind.ai;
 
-public record AiChatResponse(String answer, String provider, long latencyMs) {}
+public record AiChatResponse(String answer, String provider, long latencyMs, String sessionId) {}

--- a/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
+++ b/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
@@ -42,12 +42,30 @@ class AiChatControllerTest {
         .perform(
             post("/api/ai/chat")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""
-                    {"message":"안녕"}
+                .content(
+                    """
+                    {"message":"안녕","sessionId":"s-1"}
                     """))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.provider").value("ollama"))
         .andExpect(jsonPath("$.answer").value("안녕하세요."))
-        .andExpect(jsonPath("$.latencyMs").exists());
+        .andExpect(jsonPath("$.latencyMs").exists())
+        .andExpect(jsonPath("$.sessionId").value("s-1"));
+  }
+
+  @Test
+  void shouldAllowNullSessionId() throws Exception {
+    when(aiChatService.chat("테스트")).thenReturn("응답");
+
+    mockMvc
+        .perform(
+            post("/api/ai/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"message":"테스트"}
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.answer").value("응답"))
+        .andExpect(jsonPath("$.sessionId").isEmpty());
   }
 }


### PR DESCRIPTION
## 변경 내용
- /api/ai/chat 요청에 optional sessionId 지원 추가
- 응답에 sessionId echo 필드 추가
- latencyMs/provider/answer 기존 필드 유지
- 테스트에 sessionId 입력/미입력 케이스 추가
- README 예시 및 설명 업데이트

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/ai/AiChatRequest.java
- backend/src/main/java/com/flowmind/ai/AiChatResponse.java
- backend/src/main/java/com/flowmind/ai/AiChatController.java
- backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
- backend/README.md

## 핸드오프: 검증 결과
- /api/ai/chat 응답의 sessionId/latencyMs 확인
- spotlessCheck/test 통과

## 핸드오프: 남은 리스크
- sessionId는 단순 echo 수준이라, 서버측 세션 스토리지 연동은 별도 작업 필요

## 관련 이슈
- closes #32