### PR TITLE
feat: standardize ai chat error codes

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -65,3 +65,4 @@ The bootstrap defaults are set to start without requiring a live database connec
 `/api/dispatch/metrics?window=N`은 최근 N요청 추세 지표를 제공하며 N은 1~200으로 보정된다.
 최근 구간 요약으로 `recentFallbackCount`, `recentFallbackRate`, `recentFallbackLatencyAvgMs`도 함께 제공된다.
 `/api/ai/chat` 응답에는 `latencyMs`, `sessionId`가 포함된다.
+`/api/ai/chat` 오류 응답에는 `errorCode`(`INVALID_REQUEST`, `LLM_UNAVAILABLE`)가 포함된다.

--- a/backend/src/main/java/com/flowmind/ai/AiChatController.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatController.java
@@ -25,7 +25,8 @@ public class AiChatController {
     String message = request == null ? null : request.message();
     String sessionId = request == null ? null : request.sessionId();
     if (message == null || message.isBlank()) {
-      return ResponseEntity.badRequest().body(Map.of("error", "message is required"));
+      return ResponseEntity.badRequest()
+          .body(Map.of("errorCode", "INVALID_REQUEST", "error", "message is required"));
     }
 
     try {
@@ -34,7 +35,11 @@ public class AiChatController {
       return ResponseEntity.ok(new AiChatResponse(answer, "ollama", latencyMs, sessionId));
     } catch (RuntimeException ex) {
       return ResponseEntity.status(503)
-          .body(Map.of("error", "llm_unavailable", "detail", ex.getMessage()));
+          .body(
+              Map.of(
+                  "errorCode", "LLM_UNAVAILABLE",
+                  "error", "llm_unavailable",
+                  "detail", ex.getMessage()));
     }
   }
 }

--- a/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
+++ b/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
@@ -31,6 +31,7 @@ class AiChatControllerTest {
                     {"message":" "}
                     """))
         .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errorCode").value("INVALID_REQUEST"))
         .andExpect(jsonPath("$.error").value("message is required"));
   }
 
@@ -67,5 +68,23 @@ class AiChatControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.answer").value("응답"))
         .andExpect(jsonPath("$.sessionId").isEmpty());
+  }
+
+  @Test
+  void shouldReturnServiceUnavailableErrorCodeWhenLlmFails() throws Exception {
+    when(aiChatService.chat("장애테스트")).thenThrow(new RuntimeException("connection refused"));
+
+    mockMvc
+        .perform(
+            post("/api/ai/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {"message":"장애테스트","sessionId":"s-err"}
+                    """))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.errorCode").value("LLM_UNAVAILABLE"))
+        .andExpect(jsonPath("$.error").value("llm_unavailable"))
+        .andExpect(jsonPath("$.detail").exists());
   }
 }


### PR DESCRIPTION
## 변경 내용
- /api/ai/chat 오류 응답에 errorCode 필드 추가
- 표준 코드 적용
  - INVALID_REQUEST (400)
  - LLM_UNAVAILABLE (503)
- 기존 error, detail 필드 호환 유지
- 테스트/README 업데이트

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/ai/AiChatController.java
- backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
- backend/README.md

## 핸드오프: 검증 결과
- 400/503 응답의 errorCode 검증 통과
- spotlessCheck/test 통과

## 핸드오프: 남은 리스크
- 에러 코드 체계는 /api/ai/chat에 우선 적용되어, API 전역 공통 에러 포맷 확장은 후속 작업 필요

## 관련 이슈
- closes #34