### PR TITLE
feat: add timestamp to ai chat error responses

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -66,3 +66,4 @@ The bootstrap defaults are set to start without requiring a live database connec
 최근 구간 요약으로 `recentFallbackCount`, `recentFallbackRate`, `recentFallbackLatencyAvgMs`도 함께 제공된다.
 `/api/ai/chat` 응답에는 `latencyMs`, `sessionId`가 포함된다.
 `/api/ai/chat` 오류 응답에는 `errorCode`(`INVALID_REQUEST`, `LLM_UNAVAILABLE`)가 포함된다.
+`/api/ai/chat` 오류 응답에는 `timestamp`(ISO-8601)도 포함된다.

--- a/backend/src/main/java/com/flowmind/ai/AiChatController.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatController.java
@@ -26,7 +26,11 @@ public class AiChatController {
     String sessionId = request == null ? null : request.sessionId();
     if (message == null || message.isBlank()) {
       return ResponseEntity.badRequest()
-          .body(Map.of("errorCode", "INVALID_REQUEST", "error", "message is required"));
+          .body(
+              Map.of(
+                  "errorCode", "INVALID_REQUEST",
+                  "error", "message is required",
+                  "timestamp", Instant.now().toString()));
     }
 
     try {
@@ -37,9 +41,14 @@ public class AiChatController {
       return ResponseEntity.status(503)
           .body(
               Map.of(
-                  "errorCode", "LLM_UNAVAILABLE",
-                  "error", "llm_unavailable",
-                  "detail", ex.getMessage()));
+                  "errorCode",
+                  "LLM_UNAVAILABLE",
+                  "error",
+                  "llm_unavailable",
+                  "detail",
+                  ex.getMessage(),
+                  "timestamp",
+                  Instant.now().toString()));
     }
   }
 }

--- a/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
+++ b/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
@@ -32,7 +32,8 @@ class AiChatControllerTest {
                     """))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.errorCode").value("INVALID_REQUEST"))
-        .andExpect(jsonPath("$.error").value("message is required"));
+        .andExpect(jsonPath("$.error").value("message is required"))
+        .andExpect(jsonPath("$.timestamp").exists());
   }
 
   @Test
@@ -85,6 +86,7 @@ class AiChatControllerTest {
         .andExpect(status().isServiceUnavailable())
         .andExpect(jsonPath("$.errorCode").value("LLM_UNAVAILABLE"))
         .andExpect(jsonPath("$.error").value("llm_unavailable"))
-        .andExpect(jsonPath("$.detail").exists());
+        .andExpect(jsonPath("$.detail").exists())
+        .andExpect(jsonPath("$.timestamp").exists());
   }
 }


### PR DESCRIPTION
## 변경 내용
- /api/ai/chat 오류 응답에 	imestamp(ISO-8601) 추가
- 400(INVALID_REQUEST)/503(LLM_UNAVAILABLE) 모두 동일 포맷 적용
- 테스트/README 업데이트

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/ai/AiChatController.java
- backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
- backend/README.md

## 핸드오프: 검증 결과
- 오류 응답의 errorCode, 	imestamp 필드 검증 통과
- spotlessCheck/test 통과

## 핸드오프: 남은 리스크
- 오류 응답 포맷은 /api/ai/chat에 우선 적용되어 전역 예외 핸들러 통합은 후속 과제

## 관련 이슈
- closes #36