### PR TITLE
feat: include model in ai chat response

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -64,6 +64,6 @@ The bootstrap defaults are set to start without requiring a live database connec
 `/api/dispatch/metrics`는 `fallbackReasonCounts`, `fallbackReasonRates`, `fallbackReasonRatesWithinFallback`를 함께 제공한다.
 `/api/dispatch/metrics?window=N`은 최근 N요청 추세 지표를 제공하며 N은 1~200으로 보정된다.
 최근 구간 요약으로 `recentFallbackCount`, `recentFallbackRate`, `recentFallbackLatencyAvgMs`도 함께 제공된다.
-`/api/ai/chat` 응답에는 `latencyMs`, `sessionId`가 포함된다.
+`/api/ai/chat` 응답에는 `provider`, `model`, `latencyMs`, `sessionId`가 포함된다.
 `/api/ai/chat` 오류 응답에는 `errorCode`(`INVALID_REQUEST`, `LLM_UNAVAILABLE`)가 포함된다.
 `/api/ai/chat` 오류 응답에는 `timestamp`(ISO-8601)도 포함된다.

--- a/backend/src/main/java/com/flowmind/ai/AiChatController.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatController.java
@@ -3,6 +3,7 @@ package com.flowmind.ai;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,9 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class AiChatController {
 
   private final AiChatService aiChatService;
+  private final String chatModel;
 
-  public AiChatController(AiChatService aiChatService) {
+  public AiChatController(
+      AiChatService aiChatService,
+      @Value("${spring.ai.ollama.chat.options.model:qwen2.5:7b}") String chatModel) {
     this.aiChatService = aiChatService;
+    this.chatModel = chatModel;
   }
 
   @PostMapping("/chat")
@@ -36,7 +41,8 @@ public class AiChatController {
     try {
       String answer = aiChatService.chat(message);
       long latencyMs = Duration.between(start, Instant.now()).toMillis();
-      return ResponseEntity.ok(new AiChatResponse(answer, "ollama", latencyMs, sessionId));
+      return ResponseEntity.ok(
+          new AiChatResponse(answer, "ollama", chatModel, latencyMs, sessionId));
     } catch (RuntimeException ex) {
       return ResponseEntity.status(503)
           .body(

--- a/backend/src/main/java/com/flowmind/ai/AiChatResponse.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatResponse.java
@@ -1,3 +1,4 @@
 package com.flowmind.ai;
 
-public record AiChatResponse(String answer, String provider, long latencyMs, String sessionId) {}
+public record AiChatResponse(
+    String answer, String provider, String model, long latencyMs, String sessionId) {}

--- a/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
+++ b/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
@@ -50,6 +50,7 @@ class AiChatControllerTest {
                     """))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.provider").value("ollama"))
+        .andExpect(jsonPath("$.model").exists())
         .andExpect(jsonPath("$.answer").value("안녕하세요."))
         .andExpect(jsonPath("$.latencyMs").exists())
         .andExpect(jsonPath("$.sessionId").value("s-1"));


### PR DESCRIPTION
## 변경 내용
- /api/ai/chat 정상 응답에 model 필드 추가
- 모델 값은 spring.ai.ollama.chat.options.model 설정을 반영
- 기존 응답 필드(nswer, provider, latencyMs, sessionId) 유지
- 테스트/README 업데이트

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/ai/AiChatController.java
- backend/src/main/java/com/flowmind/ai/AiChatResponse.java
- backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
- backend/README.md

## 핸드오프: 검증 결과
- /api/ai/chat 응답의 model 필드 검증 통과
- spotlessCheck/test 통과

## 핸드오프: 남은 리스크
- 응답 model은 현재 config 기준 값이며, 런타임 동적 라우팅 도입 시 실제 호출 모델과 불일치 가능성 검토 필요

## 관련 이슈
- closes #38