### PR TITLE
feat: add request id to ai chat responses

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -64,6 +64,6 @@ The bootstrap defaults are set to start without requiring a live database connec
 `/api/dispatch/metrics`는 `fallbackReasonCounts`, `fallbackReasonRates`, `fallbackReasonRatesWithinFallback`를 함께 제공한다.
 `/api/dispatch/metrics?window=N`은 최근 N요청 추세 지표를 제공하며 N은 1~200으로 보정된다.
 최근 구간 요약으로 `recentFallbackCount`, `recentFallbackRate`, `recentFallbackLatencyAvgMs`도 함께 제공된다.
-`/api/ai/chat` 응답에는 `provider`, `model`, `latencyMs`, `sessionId`가 포함된다.
+`/api/ai/chat` 응답에는 `provider`, `model`, `latencyMs`, `sessionId`, `requestId`가 포함된다.
 `/api/ai/chat` 오류 응답에는 `errorCode`(`INVALID_REQUEST`, `LLM_UNAVAILABLE`)가 포함된다.
-`/api/ai/chat` 오류 응답에는 `timestamp`(ISO-8601)도 포함된다.
+`/api/ai/chat` 오류 응답에는 `timestamp`(ISO-8601), `requestId`도 포함된다.

--- a/backend/src/main/java/com/flowmind/ai/AiChatController.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatController.java
@@ -3,6 +3,7 @@ package com.flowmind.ai;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,26 +28,34 @@ public class AiChatController {
   @PostMapping("/chat")
   public ResponseEntity<?> chat(@RequestBody AiChatRequest request) {
     Instant start = Instant.now();
+    String requestId = UUID.randomUUID().toString();
     String message = request == null ? null : request.message();
     String sessionId = request == null ? null : request.sessionId();
     if (message == null || message.isBlank()) {
       return ResponseEntity.badRequest()
           .body(
               Map.of(
-                  "errorCode", "INVALID_REQUEST",
-                  "error", "message is required",
-                  "timestamp", Instant.now().toString()));
+                  "requestId",
+                  requestId,
+                  "errorCode",
+                  "INVALID_REQUEST",
+                  "error",
+                  "message is required",
+                  "timestamp",
+                  Instant.now().toString()));
     }
 
     try {
       String answer = aiChatService.chat(message);
       long latencyMs = Duration.between(start, Instant.now()).toMillis();
       return ResponseEntity.ok(
-          new AiChatResponse(answer, "ollama", chatModel, latencyMs, sessionId));
+          new AiChatResponse(answer, "ollama", chatModel, latencyMs, sessionId, requestId));
     } catch (RuntimeException ex) {
       return ResponseEntity.status(503)
           .body(
               Map.of(
+                  "requestId",
+                  requestId,
                   "errorCode",
                   "LLM_UNAVAILABLE",
                   "error",

--- a/backend/src/main/java/com/flowmind/ai/AiChatResponse.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatResponse.java
@@ -1,4 +1,9 @@
 package com.flowmind.ai;
 
 public record AiChatResponse(
-    String answer, String provider, String model, long latencyMs, String sessionId) {}
+    String answer,
+    String provider,
+    String model,
+    long latencyMs,
+    String sessionId,
+    String requestId) {}

--- a/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
+++ b/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
@@ -31,6 +31,7 @@ class AiChatControllerTest {
                     {"message":" "}
                     """))
         .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.requestId").exists())
         .andExpect(jsonPath("$.errorCode").value("INVALID_REQUEST"))
         .andExpect(jsonPath("$.error").value("message is required"))
         .andExpect(jsonPath("$.timestamp").exists());
@@ -53,7 +54,8 @@ class AiChatControllerTest {
         .andExpect(jsonPath("$.model").exists())
         .andExpect(jsonPath("$.answer").value("안녕하세요."))
         .andExpect(jsonPath("$.latencyMs").exists())
-        .andExpect(jsonPath("$.sessionId").value("s-1"));
+        .andExpect(jsonPath("$.sessionId").value("s-1"))
+        .andExpect(jsonPath("$.requestId").exists());
   }
 
   @Test
@@ -69,7 +71,8 @@ class AiChatControllerTest {
                     """))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.answer").value("응답"))
-        .andExpect(jsonPath("$.sessionId").isEmpty());
+        .andExpect(jsonPath("$.sessionId").isEmpty())
+        .andExpect(jsonPath("$.requestId").exists());
   }
 
   @Test
@@ -88,6 +91,7 @@ class AiChatControllerTest {
         .andExpect(jsonPath("$.errorCode").value("LLM_UNAVAILABLE"))
         .andExpect(jsonPath("$.error").value("llm_unavailable"))
         .andExpect(jsonPath("$.detail").exists())
-        .andExpect(jsonPath("$.timestamp").exists());
+        .andExpect(jsonPath("$.timestamp").exists())
+        .andExpect(jsonPath("$.requestId").exists());
   }
 }


### PR DESCRIPTION
## 변경 내용
- /api/ai/chat 정상/오류 응답 모두에 equestId 추가
- equestId는 요청당 UUID로 서버에서 생성
- 기존 필드(model, sessionId, latencyMs, errorCode, 	imestamp) 유지
- 테스트/README 업데이트

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/ai/AiChatController.java
- backend/src/main/java/com/flowmind/ai/AiChatResponse.java
- backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
- backend/README.md

## 핸드오프: 검증 결과
- 정상/오류 응답의 requestId 필드 검증 통과
- spotlessCheck/test 통과

## 핸드오프: 남은 리스크
- requestId는 현재 응답 전용이며 로그/추적 시스템과의 상관관계 연동은 후속 과제

## 관련 이슈
- closes #40