### PR TITLE
feat: add status field to ai chat responses

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -64,6 +64,6 @@ The bootstrap defaults are set to start without requiring a live database connec
 `/api/dispatch/metrics`는 `fallbackReasonCounts`, `fallbackReasonRates`, `fallbackReasonRatesWithinFallback`를 함께 제공한다.
 `/api/dispatch/metrics?window=N`은 최근 N요청 추세 지표를 제공하며 N은 1~200으로 보정된다.
 최근 구간 요약으로 `recentFallbackCount`, `recentFallbackRate`, `recentFallbackLatencyAvgMs`도 함께 제공된다.
-`/api/ai/chat` 응답에는 `provider`, `model`, `latencyMs`, `sessionId`, `requestId`가 포함된다.
+`/api/ai/chat` 응답에는 `status`, `provider`, `model`, `latencyMs`, `sessionId`, `requestId`가 포함된다.
 `/api/ai/chat` 오류 응답에는 `errorCode`(`INVALID_REQUEST`, `LLM_UNAVAILABLE`)가 포함된다.
-`/api/ai/chat` 오류 응답에는 `timestamp`(ISO-8601), `requestId`도 포함된다.
+`/api/ai/chat` 오류 응답에는 `status=error`, `timestamp`(ISO-8601), `requestId`도 포함된다.

--- a/backend/src/main/java/com/flowmind/ai/AiChatController.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatController.java
@@ -37,6 +37,8 @@ public class AiChatController {
               Map.of(
                   "requestId",
                   requestId,
+                  "status",
+                  "error",
                   "errorCode",
                   "INVALID_REQUEST",
                   "error",
@@ -49,13 +51,16 @@ public class AiChatController {
       String answer = aiChatService.chat(message);
       long latencyMs = Duration.between(start, Instant.now()).toMillis();
       return ResponseEntity.ok(
-          new AiChatResponse(answer, "ollama", chatModel, latencyMs, sessionId, requestId));
+          new AiChatResponse(
+              "success", answer, "ollama", chatModel, latencyMs, sessionId, requestId));
     } catch (RuntimeException ex) {
       return ResponseEntity.status(503)
           .body(
               Map.of(
                   "requestId",
                   requestId,
+                  "status",
+                  "error",
                   "errorCode",
                   "LLM_UNAVAILABLE",
                   "error",

--- a/backend/src/main/java/com/flowmind/ai/AiChatResponse.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatResponse.java
@@ -1,6 +1,7 @@
 package com.flowmind.ai;
 
 public record AiChatResponse(
+    String status,
     String answer,
     String provider,
     String model,

--- a/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
+++ b/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
@@ -32,6 +32,7 @@ class AiChatControllerTest {
                     """))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.requestId").exists())
+        .andExpect(jsonPath("$.status").value("error"))
         .andExpect(jsonPath("$.errorCode").value("INVALID_REQUEST"))
         .andExpect(jsonPath("$.error").value("message is required"))
         .andExpect(jsonPath("$.timestamp").exists());
@@ -50,6 +51,7 @@ class AiChatControllerTest {
                     {"message":"안녕","sessionId":"s-1"}
                     """))
         .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("success"))
         .andExpect(jsonPath("$.provider").value("ollama"))
         .andExpect(jsonPath("$.model").exists())
         .andExpect(jsonPath("$.answer").value("안녕하세요."))
@@ -70,6 +72,7 @@ class AiChatControllerTest {
                     {"message":"테스트"}
                     """))
         .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("success"))
         .andExpect(jsonPath("$.answer").value("응답"))
         .andExpect(jsonPath("$.sessionId").isEmpty())
         .andExpect(jsonPath("$.requestId").exists());
@@ -88,6 +91,7 @@ class AiChatControllerTest {
                     {"message":"장애테스트","sessionId":"s-err"}
                     """))
         .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.status").value("error"))
         .andExpect(jsonPath("$.errorCode").value("LLM_UNAVAILABLE"))
         .andExpect(jsonPath("$.error").value("llm_unavailable"))
         .andExpect(jsonPath("$.detail").exists())


### PR DESCRIPTION
## 변경 내용
- /api/ai/chat 정상 응답에 status=success 추가
- 오류 응답에 status=error 추가
- 기존 필드(equestId, errorCode, 	imestamp, model, sessionId, latencyMs) 유지
- 테스트/README 업데이트

## 검증
- backend\\gradlew.bat spotlessApply test: PASS
- backend\\gradlew.bat spotlessCheck test: PASS

## 핸드오프: 변경 파일 목록
- backend/src/main/java/com/flowmind/ai/AiChatController.java
- backend/src/main/java/com/flowmind/ai/AiChatResponse.java
- backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
- backend/README.md

## 핸드오프: 검증 결과
- 정상/오류 응답의 status 필드 검증 통과
- spotlessCheck/test 통과

## 핸드오프: 남은 리스크
- status는 현재 /api/ai/chat에만 적용되어 API 전역 공통 응답 포맷 통합은 후속 과제

## 관련 이슈
- closes #42