### PR TITLE
feat: add /api/ai/chat max message length guardrail

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -67,3 +67,4 @@ The bootstrap defaults are set to start without requiring a live database connec
 `/api/ai/chat` 응답에는 `status`, `provider`, `model`, `latencyMs`, `sessionId`, `requestId`가 포함된다.
 `/api/ai/chat` 오류 응답에는 `errorCode`(`INVALID_REQUEST`, `LLM_UNAVAILABLE`)가 포함된다.
 `/api/ai/chat` 오류 응답에는 `status=error`, `timestamp`(ISO-8601), `requestId`도 포함된다.
+`/api/ai/chat` 요청의 `message` 길이는 최대 2000자로 제한된다.

--- a/backend/src/main/java/com/flowmind/ai/AiChatController.java
+++ b/backend/src/main/java/com/flowmind/ai/AiChatController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/ai")
 public class AiChatController {
 
+  private static final int MAX_MESSAGE_LENGTH = 2000;
   private final AiChatService aiChatService;
   private final String chatModel;
 
@@ -43,6 +44,21 @@ public class AiChatController {
                   "INVALID_REQUEST",
                   "error",
                   "message is required",
+                  "timestamp",
+                  Instant.now().toString()));
+    }
+    if (message.length() > MAX_MESSAGE_LENGTH) {
+      return ResponseEntity.badRequest()
+          .body(
+              Map.of(
+                  "requestId",
+                  requestId,
+                  "status",
+                  "error",
+                  "errorCode",
+                  "INVALID_REQUEST",
+                  "error",
+                  "message length must be <= " + MAX_MESSAGE_LENGTH,
                   "timestamp",
                   Instant.now().toString()));
     }

--- a/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
+++ b/backend/src/test/java/com/flowmind/ai/AiChatControllerTest.java
@@ -5,6 +5,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -58,6 +60,23 @@ class AiChatControllerTest {
         .andExpect(jsonPath("$.latencyMs").exists())
         .andExpect(jsonPath("$.sessionId").value("s-1"))
         .andExpect(jsonPath("$.requestId").exists());
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenMessageTooLong() throws Exception {
+    String longMessage = IntStream.range(0, 2001).mapToObj(i -> "a").collect(Collectors.joining());
+
+    mockMvc
+        .perform(
+            post("/api/ai/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"message\":\"" + longMessage + "\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.requestId").exists())
+        .andExpect(jsonPath("$.status").value("error"))
+        .andExpect(jsonPath("$.errorCode").value("INVALID_REQUEST"))
+        .andExpect(jsonPath("$.error").value("message length must be <= 2000"))
+        .andExpect(jsonPath("$.timestamp").exists());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add `/api/ai/chat` message max length guardrail (<= 2000)
- return `400 INVALID_REQUEST` with existing error envelope when exceeded
- add controller test for over-length request
- document message length limit in backend README

## Validation
- `backend\\gradlew.bat spotlessApply test`