### PR TITLE
feat: refine strict-gate for docs/planning consistency

### DIFF
--- a/docs/operations/orchestrator-manager-automation.md
+++ b/docs/operations/orchestrator-manager-automation.md
@@ -68,8 +68,10 @@ node scripts/orchestrator-manager.mjs run --execute --create-worktrees --comment
 
 3. docs/planning lint
 - 변경된 `docs/*.md` 링크 무결성 검사
+- `docs/planning/*.md`의 `상태: \`...\`` 값 검사
 - `docs/planning/PHASES.md`의 phase 상태 형식/값 검사
 - 허용 상태값: `pending`, `in_progress`, `completed`
+- `docs/operations/orchestrator-manager-automation.md`의 상태 카탈로그(`planned`, `running`, `dispatched`, `failed`, `done`) 일관성 검사
 
 ## PR 템플릿 자동 연동
 

--- a/scripts/orchestrator-manager.mjs
+++ b/scripts/orchestrator-manager.mjs
@@ -339,6 +339,48 @@ export function validatePhasesStatusText(markdown) {
   return { ok: errors.length === 0, errors };
 }
 
+const ALLOWED_PHASE_STATUS = new Set(['pending', 'in_progress', 'completed']);
+const ALLOWED_ORCHESTRATOR_STATUS = new Set(['planned', 'running', 'dispatched', 'failed', 'done']);
+
+export function validatePlanningStatusMarkers(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  const errors = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = lines[i].match(/상태:\s*`([^`]+)`/);
+    if (!match) continue;
+    if (!ALLOWED_PHASE_STATUS.has(match[1])) {
+      errors.push(`invalid planning status "${match[1]}" near line ${i + 1}`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+export function validateOrchestratorAutomationStatusText(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  const statusLine = lines.find((line) => line.includes('상태값:'));
+  if (!statusLine) {
+    return { ok: false, errors: ['missing orchestrator 상태값 line'] };
+  }
+
+  const values = Array.from(statusLine.matchAll(/`([^`]+)`/g)).map((entry) => entry[1].trim());
+  const errors = [];
+
+  for (const value of values) {
+    if (!ALLOWED_ORCHESTRATOR_STATUS.has(value)) {
+      errors.push(`invalid orchestrator status "${value}"`);
+    }
+  }
+  for (const required of ALLOWED_ORCHESTRATOR_STATUS) {
+    if (!values.includes(required)) {
+      errors.push(`missing orchestrator status "${required}"`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
 async function runDocsPlanningLint(worktreeAbsPath, changedFiles, domain) {
   const failures = [];
   const markdownFiles = changedFiles.filter(
@@ -351,6 +393,18 @@ async function runDocsPlanningLint(worktreeAbsPath, changedFiles, domain) {
     if (!exists) continue;
     const brokenLinks = await collectBrokenLinksInFile(fileAbsPath, worktreeAbsPath);
     failures.push(...brokenLinks.map((entry) => `broken-link: ${entry}`));
+
+    const markdown = await fs.readFile(fileAbsPath, 'utf8');
+    if (file.startsWith('docs/planning/')) {
+      const planningStatus = validatePlanningStatusMarkers(markdown);
+      failures.push(...planningStatus.errors.map((error) => `planning-status: ${file}: ${error}`));
+    }
+    if (file === 'docs/operations/orchestrator-manager-automation.md') {
+      const orchestratorStatus = validateOrchestratorAutomationStatusText(markdown);
+      failures.push(
+        ...orchestratorStatus.errors.map((error) => `orchestrator-status: ${file}: ${error}`)
+      );
+    }
   }
 
   const shouldCheckPhases =

--- a/scripts/orchestrator-manager.spec.mjs
+++ b/scripts/orchestrator-manager.spec.mjs
@@ -9,6 +9,8 @@ import {
   slugify,
   extractMarkdownLinks,
   validatePhasesStatusText,
+  validatePlanningStatusMarkers,
+  validateOrchestratorAutomationStatusText,
 } from './orchestrator-manager.mjs';
 
 function run(name, fn) {
@@ -110,6 +112,26 @@ run('validatePhasesStatusText validates status values', () => {
 `;
   assert.equal(validatePhasesStatusText(valid).ok, true);
   assert.equal(validatePhasesStatusText(invalid).ok, false);
+});
+
+run('validatePlanningStatusMarkers validates planning 상태 markers', () => {
+  const valid = `
+- 상태: \`pending\`
+- 상태: \`in_progress\`
+- 상태: \`completed\`
+`;
+  const invalid = `
+- 상태: \`done\`
+`;
+  assert.equal(validatePlanningStatusMarkers(valid).ok, true);
+  assert.equal(validatePlanningStatusMarkers(invalid).ok, false);
+});
+
+run('validateOrchestratorAutomationStatusText validates orchestrator status catalog', () => {
+  const valid = '- 상태값: `planned`, `running`, `dispatched`, `failed`, `done`';
+  const invalid = '- 상태값: `planned`, `running`, `done`';
+  assert.equal(validateOrchestratorAutomationStatusText(valid).ok, true);
+  assert.equal(validateOrchestratorAutomationStatusText(invalid).ok, false);
 });
 
 console.log('All orchestrator-manager checks passed.');


### PR DESCRIPTION
## Summary
- refine strict-gate for docs/planning domain changes
- add planning status marker validation (`상태: \`pending|in_progress|completed\``)
- add orchestrator status catalog validation in `docs/operations/orchestrator-manager-automation.md`
- keep markdown link integrity checks and phase status checks
- add/update orchestrator manager spec tests

## Validation
- `node scripts/orchestrator-manager.spec.mjs`

## Handoff
### 변경 파일 목록
- scripts/orchestrator-manager.mjs
- scripts/orchestrator-manager.spec.mjs
- docs/operations/orchestrator-manager-automation.md

### 검증 결과
- orchestrator-manager spec tests: pass

### 남은 리스크
- 현재 링크 검사는 로컬 파일 경로 기준이며 외부 URL 유효성은 검사하지 않음