### PR TITLE
feat: add spec-to-planning sync automation

### DIFF
--- a/docs/guides/spec-kit-adoption.md
+++ b/docs/guides/spec-kit-adoption.md
@@ -52,6 +52,17 @@ node scripts/orchestrator-manager.mjs run --execute --create-worktrees --comment
 ## 5) 운영 규칙
 
 - PR 본문은 우선 `.codex/orchestrator/pr-bodies/issue-<n>.md`를 사용한다.
+- spec 산출물을 planning 실행계획으로 동기화할 때:
+
+```powershell
+# 미리보기
+node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops --dry-run
+
+# 파일 생성
+node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops
+```
+
+- 생성 대상: `docs/planning/exec-plans/active/<feature>.md`
 - 자동 생성이 없는 경우:
 
 ```powershell

--- a/docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md
+++ b/docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md
@@ -1,0 +1,58 @@
+# FlowMind Finance VoiceOps MVP Execution Plan
+
+- source-spec: specs/001-flowmind-finance-voiceops/spec.md
+- generated-at: 2026-04-30T08:24:42.442Z
+
+## 제목
+- FlowMind Finance VoiceOps MVP
+
+## 목표
+- **FR-001**: System MUST classify user requests into `ACCOUNT_INFO_INQUIRY`, `TRANSACTION_HISTORY_INQUIRY`, `CARD_LOST_OR_LIMIT`, or `LLM_FALLBACK`.
+- **FR-002**: System MUST perform slot-filling for each intent and return follow-up prompts for missing required slots.
+- **FR-003**: System MUST apply identity verification before returning account-sensitive information.
+- **FR-004**: System MUST route to LLM fallback when confidence is below threshold, request is composite, or complaint/sentiment escalation is detected.
+- **FR-005**: System MUST return standardized response envelope including `status`, `requestId`, and timestamped errors where applicable.
+
+## 범위
+- Developed independently
+- Tested independently
+- Deployed independently
+- Demonstrated to users independently
+1. **Given** 고객이 인증 슬롯을 모두 제공한 상태, **When** 계좌 정보를 요청하면, **Then** 인증 성공 후 계좌 요약이 반환된다.
+2. **Given** 인증 슬롯 일부가 누락된 상태, **When** 계좌 정보를 요청하면, **Then** 누락 슬롯에 대한 후속 질문이 반환된다.
+
+## 비범위
+- 외부 연계 시스템 실제 운영 전환
+- 인프라/배포 파이프라인 전체 재설계
+
+## 예상 변경 파일
+- backend/** (필요 기능 구현 시)
+- docs/planning/**
+- specs/**
+
+## 리스크
+- spec 요구사항 대비 구현 누락 가능성
+- 슬롯/의도 경계 케이스 오분류 가능성
+- LLM fallback 정책 과/소적용 가능성
+
+## 작업 단계
+1. spec 요구사항 매핑
+2. API/도메인 설계
+3. 구현
+4. 테스트/검증
+5. 문서 및 운영 반영
+
+## 검증 기준
+- **SC-001**: P1 시나리오(본인확인 후 계좌안내) 성공률이 테스트 데이터 기준 95% 이상이다.
+- **SC-002**: 슬롯 누락 후속 질문 정확도가 90% 이상이다.
+- **SC-003**: LLM fallback 비율이 전체 요청의 35% 이하로 유지된다(MVP 기준).
+- **SC-004**: `/api/ai/chat` 및 dispatch 핵심 응답 p95 latency가 2.0초 이하이다(로컬 실행 기준).
+
+## 가정
+- MVP 범위는 한국어 금융 문의 시나리오 3종으로 제한한다.
+- 음성 STT 자체 품질 개선은 범위 밖이며 텍스트 입력 정제 결과를 가정한다.
+- 인증 정보는 데모/샌드박스 데이터셋으로 검증하고 실제 금융계 원장 연동은 제외한다.
+- LLM fallback은 로컬/저비용 실행 구성을 우선 사용한다.
+
+## 진행 상태
+- `pending`

--- a/scripts/sync-spec-to-planning.mjs
+++ b/scripts/sync-spec-to-planning.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+function parseArgs(argv) {
+  const args = {
+    feature: null,
+    dryRun: false,
+    outputDir: 'docs/planning/exec-plans/active',
+  };
+
+  const tokens = argv.slice(2);
+  while (tokens.length > 0) {
+    const token = tokens.shift();
+    switch (token) {
+      case '--feature':
+        args.feature = tokens.shift() || null;
+        break;
+      case '--dry-run':
+        args.dryRun = true;
+        break;
+      case '--output-dir':
+        args.outputDir = tokens.shift() || args.outputDir;
+        break;
+      case '--help':
+        printHelp();
+        process.exit(0);
+      default:
+        throw new Error(`Unknown option: ${token}`);
+    }
+  }
+
+  if (!args.feature) {
+    throw new Error('Missing required option: --feature <id>');
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/sync-spec-to-planning.mjs --feature <feature-id> [options]
+
+Options:
+  --dry-run                  Print planned output without writing files
+  --output-dir <path>        Target directory (default: docs/planning/exec-plans/active)
+  --help                     Show help
+`);
+}
+
+function findSectionByPrefix(markdown, headingPrefix) {
+  const lines = markdown.split(/\r?\n/);
+  const startIndex = lines.findIndex((line) =>
+    line.trim().toLowerCase().startsWith(`## ${headingPrefix.toLowerCase()}`)
+  );
+  if (startIndex < 0) return '';
+
+  let endIndex = lines.length;
+  for (let i = startIndex + 1; i < lines.length; i += 1) {
+    if (lines[i].trim().startsWith('## ')) {
+      endIndex = i;
+      break;
+    }
+  }
+  return lines.slice(startIndex + 1, endIndex).join('\n').trim();
+}
+
+function firstBulletLines(block, max = 6) {
+  const lines = block
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('- ') || /^\d+\.\s+/.test(line))
+    .slice(0, max);
+  return lines.length > 0 ? lines : ['- (spec에서 수동 보완 필요)'];
+}
+
+function buildPlanMarkdown(featureId, specText) {
+  const titleMatch = specText.match(/^#\s+Feature Specification:\s*(.+)$/m);
+  const featureTitle = titleMatch ? titleMatch[1].trim() : featureId;
+  const requirements = findSectionByPrefix(specText, 'Requirements');
+  const criteria = findSectionByPrefix(specText, 'Success Criteria');
+  const assumptions = findSectionByPrefix(specText, 'Assumptions');
+  const stories = findSectionByPrefix(specText, 'User Scenarios & Testing');
+
+  const goalBullets = firstBulletLines(requirements, 5);
+  const successBullets = firstBulletLines(criteria, 5);
+  const scopeBullets = firstBulletLines(stories, 6);
+  const assumptionBullets = firstBulletLines(assumptions, 4);
+
+  return [
+    `# ${featureTitle} Execution Plan`,
+    '',
+    `- source-spec: specs/${featureId}/spec.md`,
+    `- generated-at: ${new Date().toISOString()}`,
+    '',
+    '## 제목',
+    `- ${featureTitle}`,
+    '',
+    '## 목표',
+    ...goalBullets,
+    '',
+    '## 범위',
+    ...scopeBullets,
+    '',
+    '## 비범위',
+    '- 외부 연계 시스템 실제 운영 전환',
+    '- 인프라/배포 파이프라인 전체 재설계',
+    '',
+    '## 예상 변경 파일',
+    '- backend/** (필요 기능 구현 시)',
+    '- docs/planning/**',
+    '- specs/**',
+    '',
+    '## 리스크',
+    '- spec 요구사항 대비 구현 누락 가능성',
+    '- 슬롯/의도 경계 케이스 오분류 가능성',
+    '- LLM fallback 정책 과/소적용 가능성',
+    '',
+    '## 작업 단계',
+    '1. spec 요구사항 매핑',
+    '2. API/도메인 설계',
+    '3. 구현',
+    '4. 테스트/검증',
+    '5. 문서 및 운영 반영',
+    '',
+    '## 검증 기준',
+    ...successBullets,
+    '',
+    '## 가정',
+    ...assumptionBullets,
+    '',
+    '## 진행 상태',
+    '- `pending`',
+  ].join('\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const specPath = path.resolve('specs', args.feature, 'spec.md');
+  const outputFileName = `${args.feature}.md`;
+  const outputPath = path.resolve(args.outputDir, outputFileName);
+
+  const specText = await fs.readFile(specPath, 'utf8');
+  const planText = buildPlanMarkdown(args.feature, specText);
+
+  if (args.dryRun) {
+    console.log(`DRY-RUN: ${outputPath}`);
+    console.log(planText);
+    return;
+  }
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, `${planText}\n`, 'utf8');
+  console.log(`Created: ${outputPath}`);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `scripts/sync-spec-to-planning.mjs` to sync a spec file into planning execution-plan draft
- support `--feature`, `--dry-run`, `--output-dir` options
- generate `docs/planning/exec-plans/active/<feature>.md` from `specs/<feature>/spec.md`
- update spec-kit adoption guide with sync command examples

## Verification
- `node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops --dry-run`
- `node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops`

## Handoff
### 변경 파일 목록
- scripts/sync-spec-to-planning.mjs
- docs/guides/spec-kit-adoption.md
- docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md

### 검증 결과
- dry-run output confirmed
- plan file creation confirmed

### 남은 리스크
- 현재 범위는 spec markdown의 단순 섹션 파싱 기반이라 템플릿 구조가 크게 바뀌면 보정이 필요