### PR TITLE
feat: wire spec-to-planning sync into PR creation

### DIFF
--- a/docs/guides/spec-kit-adoption.md
+++ b/docs/guides/spec-kit-adoption.md
@@ -67,6 +67,9 @@ node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops
 
 ```powershell
 node scripts/create-pr-from-issue.mjs --base dev
+
+# spec -> planning 동기화까지 한 번에 수행
+node scripts/create-pr-from-issue.mjs --base dev --sync-feature 001-flowmind-finance-voiceops
 ```
 
 - docs/planning 문서 변경 시 strict-gate lint(링크/상태 일관성)를 통과해야 한다.

--- a/docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md
+++ b/docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md
@@ -1,7 +1,7 @@
 # FlowMind Finance VoiceOps MVP Execution Plan
 
 - source-spec: specs/001-flowmind-finance-voiceops/spec.md
-- generated-at: 2026-04-30T08:24:42.442Z
+- generated-at: 2026-04-30T08:35:52.276Z
 
 ## 제목
 - FlowMind Finance VoiceOps MVP

--- a/scripts/create-pr-from-issue.mjs
+++ b/scripts/create-pr-from-issue.mjs
@@ -11,6 +11,7 @@ function parseArgs(argv) {
     head: null,
     title: null,
     dryRun: false,
+    syncFeature: null,
   };
 
   const tokens = argv.slice(2);
@@ -32,6 +33,9 @@ function parseArgs(argv) {
       case '--dry-run':
         args.dryRun = true;
         break;
+      case '--sync-feature':
+        args.syncFeature = tokens.shift() || null;
+        break;
       case '--help':
         printHelp();
         process.exit(0);
@@ -51,6 +55,7 @@ Options:
   --base <branch>    Base branch (default: dev)
   --head <branch>    Head branch (default: current branch)
   --title "<text>"   PR title (default: issue title)
+  --sync-feature <id>  Run spec->planning sync before PR creation
   --dry-run          Print gh command only
   --help             Show help
 `);
@@ -74,17 +79,18 @@ function buildBodyPath(issueNumber) {
   return path.join('.codex', 'orchestrator', 'pr-bodies', `issue-${issueNumber}.md`);
 }
 
-function resolveBodyArgs(issueNumber) {
+function resolveBodyArgs(issueNumber, syncedFile) {
   const bodyFile = buildBodyPath(issueNumber);
   if (fs.existsSync(bodyFile)) {
     return ['--body-file', bodyFile];
   }
+  const changedFileLine = syncedFile ? `- ${syncedFile}` : '- (자동 생성 PR body 파일이 없어 수동 보완 필요)';
   const fallbackBody = [
     '## 변경 내용',
     '- 이번 PR에서 바꾼 핵심 내용',
     '',
     '## 핸드오프: 변경 파일 목록',
-    '- (자동 생성 PR body 파일이 없어 수동 보완 필요)',
+    changedFileLine,
     '',
     '## 핸드오프: 검증 결과',
     '- (자동 생성 PR body 파일이 없어 수동 보완 필요)',
@@ -99,6 +105,13 @@ function resolveBodyArgs(issueNumber) {
   return ['--body', fallbackBody];
 }
 
+function runSpecPlanningSync(featureId) {
+  if (!featureId) return null;
+  const syncCommand = ['scripts/sync-spec-to-planning.mjs', '--feature', featureId];
+  execFileSync('node', syncCommand, { stdio: 'inherit' });
+  return `docs/planning/exec-plans/active/${featureId}.md`;
+}
+
 function main() {
   const args = parseArgs(process.argv);
   const currentBranch = gitText(['branch', '--show-current']);
@@ -111,7 +124,8 @@ function main() {
 
   const issue = ghJson(['issue', 'view', String(issueNumber), '--json', 'title']);
   const title = args.title || issue.title;
-  const bodyArgs = resolveBodyArgs(issueNumber);
+  const syncedFile = runSpecPlanningSync(args.syncFeature);
+  const bodyArgs = resolveBodyArgs(issueNumber, syncedFile);
 
   const command = [
     'pr',
@@ -126,6 +140,9 @@ function main() {
   ];
 
   if (args.dryRun) {
+    if (syncedFile) {
+      console.log(`synced planning file: ${syncedFile}`);
+    }
     console.log(`gh ${command.map((part) => (part.includes(' ') ? `"${part}"` : part)).join(' ')}`);
     return;
   }


### PR DESCRIPTION
## Summary
- extend `create-pr-from-issue` with `--sync-feature <id>` option
- run `sync-spec-to-planning` automatically before PR creation when option is provided
- include synced planning file path in fallback PR handoff section
- update spec-kit adoption guide with one-command sync+PR example

## Verification
- `node scripts/create-pr-from-issue.mjs --dry-run`
- `node scripts/create-pr-from-issue.mjs --dry-run --sync-feature 001-flowmind-finance-voiceops`

## Handoff
### 변경 파일 목록
- scripts/create-pr-from-issue.mjs
- docs/guides/spec-kit-adoption.md
- docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md

### 검증 결과
- dry-run without sync: pass
- dry-run with sync: planning file generated and command output includes synced file path

### 남은 리스크
- sync 단계는 현재 파일 생성 성공만 보장하며, 생성 내용 품질은 별도 리뷰 필요