### PR TITLE
feat: enforce spec-planning sync consistency in strict-gate

### DIFF
--- a/docs/operations/orchestrator-manager-automation.md
+++ b/docs/operations/orchestrator-manager-automation.md
@@ -72,6 +72,8 @@ node scripts/orchestrator-manager.mjs run --execute --create-worktrees --comment
 - `docs/planning/PHASES.md`의 phase 상태 형식/값 검사
 - 허용 상태값: `pending`, `in_progress`, `completed`
 - `docs/operations/orchestrator-manager-automation.md`의 상태 카탈로그(`planned`, `running`, `dispatched`, `failed`, `done`) 일관성 검사
+- spec/planning 동기화 정합성 검사: `specs/<id>/spec.md` <-> `docs/planning/exec-plans/active/<id>.md`
+- planning 파일에는 `- source-spec: specs/<id>/spec.md` 메타가 필수
 
 ## PR 템플릿 자동 연동
 

--- a/scripts/orchestrator-manager.mjs
+++ b/scripts/orchestrator-manager.mjs
@@ -381,6 +381,83 @@ export function validateOrchestratorAutomationStatusText(markdown) {
   return { ok: errors.length === 0, errors };
 }
 
+export function parseSourceSpecFromPlan(markdown) {
+  const match = markdown.match(/^\s*-\s*source-spec:\s*(.+)\s*$/m);
+  return match ? match[1].trim() : null;
+}
+
+export function validateSpecPlanningSyncPair(specPath, planPath, planMarkdown) {
+  const errors = [];
+  const sourceSpec = parseSourceSpecFromPlan(planMarkdown);
+  if (!sourceSpec) {
+    errors.push(`missing source-spec meta in ${planPath}`);
+    return { ok: false, errors };
+  }
+
+  const normalizedSource = sourceSpec.replaceAll('\\', '/');
+  const normalizedSpecPath = specPath.replaceAll('\\', '/');
+  if (normalizedSource !== normalizedSpecPath) {
+    errors.push(`source-spec mismatch in ${planPath}: expected ${normalizedSpecPath}, got ${normalizedSource}`);
+  }
+
+  const specFeature = normalizedSpecPath.match(/^specs\/([^/]+)\/spec\.md$/)?.[1];
+  const planFeature = planPath.match(/^docs\/planning\/exec-plans\/active\/(.+)\.md$/)?.[1];
+  if (!specFeature || !planFeature || specFeature !== planFeature) {
+    errors.push(`feature id mismatch between ${specPath} and ${planPath}`);
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+async function validateSpecPlanningSync(worktreeAbsPath, changedFiles) {
+  const failures = [];
+  const changedSpecs = changedFiles.filter((file) => /^specs\/[^/]+\/spec\.md$/.test(file));
+  const changedPlans = changedFiles.filter((file) => /^docs\/planning\/exec-plans\/active\/.+\.md$/.test(file));
+
+  const planByFeature = new Map();
+  for (const planPath of changedPlans) {
+    const feature = planPath.match(/^docs\/planning\/exec-plans\/active\/(.+)\.md$/)?.[1];
+    if (feature) planByFeature.set(feature, planPath);
+  }
+
+  for (const specPath of changedSpecs) {
+    const feature = specPath.match(/^specs\/([^/]+)\/spec\.md$/)?.[1];
+    if (!feature) continue;
+    const pairedPlan = planByFeature.get(feature);
+    if (!pairedPlan) {
+      failures.push(`spec-sync: missing paired planning file for ${specPath}`);
+      continue;
+    }
+    const planAbsPath = path.resolve(worktreeAbsPath, pairedPlan);
+    const exists = await fileExists(planAbsPath);
+    if (!exists) {
+      failures.push(`spec-sync: missing file ${pairedPlan}`);
+      continue;
+    }
+    const planMarkdown = await fs.readFile(planAbsPath, 'utf8');
+    const result = validateSpecPlanningSyncPair(specPath, pairedPlan, planMarkdown);
+    failures.push(...result.errors.map((error) => `spec-sync: ${error}`));
+  }
+
+  for (const planPath of changedPlans) {
+    const feature = planPath.match(/^docs\/planning\/exec-plans\/active\/(.+)\.md$/)?.[1];
+    if (!feature) continue;
+    const expectedSpec = `specs/${feature}/spec.md`;
+    const specAbsPath = path.resolve(worktreeAbsPath, expectedSpec);
+    const specExists = await fileExists(specAbsPath);
+    if (!specExists) {
+      failures.push(`spec-sync: missing source spec file ${expectedSpec}`);
+      continue;
+    }
+    const planAbsPath = path.resolve(worktreeAbsPath, planPath);
+    const planMarkdown = await fs.readFile(planAbsPath, 'utf8');
+    const result = validateSpecPlanningSyncPair(expectedSpec, planPath, planMarkdown);
+    failures.push(...result.errors.map((error) => `spec-sync: ${error}`));
+  }
+
+  return failures;
+}
+
 async function runDocsPlanningLint(worktreeAbsPath, changedFiles, domain) {
   const failures = [];
   const markdownFiles = changedFiles.filter(
@@ -423,6 +500,9 @@ async function runDocsPlanningLint(worktreeAbsPath, changedFiles, domain) {
       failures.push(...validation.errors.map((error) => `phase-status: ${error}`));
     }
   }
+
+  const syncFailures = await validateSpecPlanningSync(worktreeAbsPath, changedFiles);
+  failures.push(...syncFailures);
 
   return failures;
 }

--- a/scripts/orchestrator-manager.spec.mjs
+++ b/scripts/orchestrator-manager.spec.mjs
@@ -11,6 +11,8 @@ import {
   validatePhasesStatusText,
   validatePlanningStatusMarkers,
   validateOrchestratorAutomationStatusText,
+  parseSourceSpecFromPlan,
+  validateSpecPlanningSyncPair,
 } from './orchestrator-manager.mjs';
 
 function run(name, fn) {
@@ -132,6 +134,41 @@ run('validateOrchestratorAutomationStatusText validates orchestrator status cata
   const invalid = '- 상태값: `planned`, `running`, `done`';
   assert.equal(validateOrchestratorAutomationStatusText(valid).ok, true);
   assert.equal(validateOrchestratorAutomationStatusText(invalid).ok, false);
+});
+
+run('parseSourceSpecFromPlan extracts source-spec metadata', () => {
+  const markdown = `
+# Example
+- source-spec: specs/001-demo/spec.md
+`;
+  assert.equal(parseSourceSpecFromPlan(markdown), 'specs/001-demo/spec.md');
+});
+
+run('validateSpecPlanningSyncPair validates spec/plan consistency', () => {
+  const validPlan = `
+# Plan
+- source-spec: specs/001-demo/spec.md
+`;
+  const invalidPlan = `
+# Plan
+- source-spec: specs/999-other/spec.md
+`;
+  assert.equal(
+    validateSpecPlanningSyncPair(
+      'specs/001-demo/spec.md',
+      'docs/planning/exec-plans/active/001-demo.md',
+      validPlan
+    ).ok,
+    true
+  );
+  assert.equal(
+    validateSpecPlanningSyncPair(
+      'specs/001-demo/spec.md',
+      'docs/planning/exec-plans/active/001-demo.md',
+      invalidPlan
+    ).ok,
+    false
+  );
 });
 
 console.log('All orchestrator-manager checks passed.');


### PR DESCRIPTION
## Summary
- extend strict-gate docs/planning lint with spec/planning sync consistency checks
- enforce mapping consistency between `specs/<id>/spec.md` and `docs/planning/exec-plans/active/<id>.md`
- require `- source-spec: specs/<id>/spec.md` metadata in planning files
- add orchestrator manager spec tests for source-spec parsing and pair validation
- update automation guide documentation

## Verification
- `node scripts/orchestrator-manager.spec.mjs`

## Handoff
### 변경 파일 목록
- scripts/orchestrator-manager.mjs
- scripts/orchestrator-manager.spec.mjs
- docs/operations/orchestrator-manager-automation.md

### 검증 결과
- orchestrator-manager spec tests: pass

### 남은 리스크
- 현재 검사는 변경된 파일 기준으로 동작하므로, 과거에 이미 존재하던 불일치 파일은 해당 PR에서 파일 변경이 없으면 검출되지 않음