### PR TITLE
feat: improve spec-to-planning extraction quality

### DIFF
--- a/docs/guides/spec-kit-adoption.md
+++ b/docs/guides/spec-kit-adoption.md
@@ -63,6 +63,10 @@ node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops
 ```
 
 - 생성 대상: `docs/planning/exec-plans/active/<feature>.md`
+- 추출 기준:
+  - 목표: `FR-*` 요구사항 라인 우선
+  - 범위: `Given/When/Then` 수용 시나리오 우선
+  - 검증 기준: `SC-*` 성공지표 라인 우선
 - 자동 생성이 없는 경우:
 
 ```powershell

--- a/docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md
+++ b/docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md
@@ -1,7 +1,7 @@
 # FlowMind Finance VoiceOps MVP Execution Plan
 
 - source-spec: specs/001-flowmind-finance-voiceops/spec.md
-- generated-at: 2026-04-30T08:35:52.276Z
+- generated-at: 2026-04-30T09:11:25.213Z
 
 ## 제목
 - FlowMind Finance VoiceOps MVP
@@ -12,14 +12,13 @@
 - **FR-003**: System MUST apply identity verification before returning account-sensitive information.
 - **FR-004**: System MUST route to LLM fallback when confidence is below threshold, request is composite, or complaint/sentiment escalation is detected.
 - **FR-005**: System MUST return standardized response envelope including `status`, `requestId`, and timestamped errors where applicable.
+- **FR-006**: System MUST persist fallback reason and dispatch trace for each request.
 
 ## 범위
-- Developed independently
-- Tested independently
-- Deployed independently
-- Demonstrated to users independently
 1. **Given** 고객이 인증 슬롯을 모두 제공한 상태, **When** 계좌 정보를 요청하면, **Then** 인증 성공 후 계좌 요약이 반환된다.
 2. **Given** 인증 슬롯 일부가 누락된 상태, **When** 계좌 정보를 요청하면, **Then** 누락 슬롯에 대한 후속 질문이 반환된다.
+1. **Given** 계좌와 기간만 제공된 상태, **When** 거래내역 조회 요청이 들어오면, **Then** 거래유형 누락 질문 후 슬롯 충족 시 조회 결과를 반환한다.
+1. **Given** 고객이 분실정지를 요청한 상태, **When** 인증이 완료되면, **Then** 분실정지 프로세스로 분기하고 완료/상담원 연결 응답을 반환한다.
 
 ## 비범위
 - 외부 연계 시스템 실제 운영 전환

--- a/scripts/sync-spec-to-planning.mjs
+++ b/scripts/sync-spec-to-planning.mjs
@@ -74,6 +74,24 @@ function firstBulletLines(block, max = 6) {
   return lines.length > 0 ? lines : ['- (spec에서 수동 보완 필요)'];
 }
 
+function collectPatternLines(block, pattern, max = 6) {
+  const lines = block
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => pattern.test(line))
+    .slice(0, max);
+  return lines.length > 0 ? lines : ['- (spec에서 수동 보완 필요)'];
+}
+
+function storyLines(block, max = 6) {
+  const lines = block
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^\d+\.\s+\*\*Given\*\*/.test(line))
+    .slice(0, max);
+  return lines.length > 0 ? lines : ['- (spec에서 수동 보완 필요)'];
+}
+
 function buildPlanMarkdown(featureId, specText) {
   const titleMatch = specText.match(/^#\s+Feature Specification:\s*(.+)$/m);
   const featureTitle = titleMatch ? titleMatch[1].trim() : featureId;
@@ -82,9 +100,9 @@ function buildPlanMarkdown(featureId, specText) {
   const assumptions = findSectionByPrefix(specText, 'Assumptions');
   const stories = findSectionByPrefix(specText, 'User Scenarios & Testing');
 
-  const goalBullets = firstBulletLines(requirements, 5);
-  const successBullets = firstBulletLines(criteria, 5);
-  const scopeBullets = firstBulletLines(stories, 6);
+  const goalBullets = collectPatternLines(requirements, /^- \*\*FR-\d+\*\*:/, 6);
+  const successBullets = collectPatternLines(criteria, /^- \*\*SC-\d+\*\*:/, 6);
+  const scopeBullets = storyLines(stories, 6);
   const assumptionBullets = firstBulletLines(assumptions, 4);
 
   return [


### PR DESCRIPTION
## Summary
- improve `sync-spec-to-planning` extraction quality to avoid template/noise lines
- goals now prioritize `FR-*` requirement lines
- verification criteria now prioritize `SC-*` success criteria lines
- scope now prioritizes `Given/When/Then` acceptance scenario lines
- update spec-kit adoption guide with extraction rule explanation

## Verification
- `node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops --dry-run`
- `node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops`

## Handoff
### 변경 파일 목록
- scripts/sync-spec-to-planning.mjs
- docs/guides/spec-kit-adoption.md
- docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md

### 검증 결과
- dry-run output confirmed: FR/SC and acceptance scenarios extracted without template guideline bullets
- generated plan file updated successfully

### 남은 리스크
- markdown 템플릿 구조가 크게 변하면 정규식/패턴 기준을 추가 보정해야 할 수 있음