### PR TITLE
feat: add overwrite/append-notes modes to spec sync

### DIFF
--- a/docs/guides/spec-kit-adoption.md
+++ b/docs/guides/spec-kit-adoption.md
@@ -60,9 +60,15 @@ node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops -
 
 # 파일 생성
 node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops
+
+# 수동 노트 보존 모드(리스크/진행 상태/작업 단계 유지)
+node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops --mode append-notes
 ```
 
 - 생성 대상: `docs/planning/exec-plans/active/<feature>.md`
+- 모드:
+  - `overwrite` (기본): 전체 재생성
+  - `append-notes`: 기존 문서의 수동 구간(`리스크`, `작업 단계`, `진행 상태`) 보존
 - 추출 기준:
   - 목표: `FR-*` 요구사항 라인 우선
   - 범위: `Given/When/Then` 수용 시나리오 우선

--- a/docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md
+++ b/docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md
@@ -1,8 +1,7 @@
 # FlowMind Finance VoiceOps MVP Execution Plan
 
 - source-spec: specs/001-flowmind-finance-voiceops/spec.md
-- generated-at: 2026-04-30T09:11:25.213Z
-
+- generated-at: 2026-04-30T09:25:41.895Z
 ## 제목
 - FlowMind Finance VoiceOps MVP
 
@@ -30,9 +29,7 @@
 - specs/**
 
 ## 리스크
-- spec 요구사항 대비 구현 누락 가능성
-- 슬롯/의도 경계 케이스 오분류 가능성
-- LLM fallback 정책 과/소적용 가능성
+- 사용자 수동메모: 운영 승인 필요
 
 ## 작업 단계
 1. spec 요구사항 매핑
@@ -54,4 +51,4 @@
 - LLM fallback은 로컬/저비용 실행 구성을 우선 사용한다.
 
 ## 진행 상태
-- `pending`
+- `in_progress`

--- a/scripts/sync-spec-to-planning.mjs
+++ b/scripts/sync-spec-to-planning.mjs
@@ -8,6 +8,7 @@ function parseArgs(argv) {
     feature: null,
     dryRun: false,
     outputDir: 'docs/planning/exec-plans/active',
+    mode: 'overwrite',
   };
 
   const tokens = argv.slice(2);
@@ -23,6 +24,9 @@ function parseArgs(argv) {
       case '--output-dir':
         args.outputDir = tokens.shift() || args.outputDir;
         break;
+      case '--mode':
+        args.mode = tokens.shift() || args.mode;
+        break;
       case '--help':
         printHelp();
         process.exit(0);
@@ -34,6 +38,9 @@ function parseArgs(argv) {
   if (!args.feature) {
     throw new Error('Missing required option: --feature <id>');
   }
+  if (!['overwrite', 'append-notes'].includes(args.mode)) {
+    throw new Error(`Invalid --mode value: ${args.mode} (allowed: overwrite, append-notes)`);
+  }
   return args;
 }
 
@@ -44,8 +51,55 @@ function printHelp() {
 Options:
   --dry-run                  Print planned output without writing files
   --output-dir <path>        Target directory (default: docs/planning/exec-plans/active)
+  --mode <overwrite|append-notes>
+                              overwrite: regenerate full file
+                              append-notes: keep manual notes sections from existing file
   --help                     Show help
 `);
+}
+
+function splitSections(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  const sections = [];
+  let currentTitle = '__TOP__';
+  let current = [];
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      sections.push({ title: currentTitle, body: current.join('\n').trimEnd() });
+      currentTitle = line.slice(3).trim();
+      current = [];
+      continue;
+    }
+    current.push(line);
+  }
+  sections.push({ title: currentTitle, body: current.join('\n').trimEnd() });
+  return sections;
+}
+
+function mergePlanWithExisting(generatedText, existingText) {
+  const preserveTitles = new Set(['리스크', '진행 상태', '작업 단계']);
+  const generatedSections = splitSections(generatedText);
+  const existingSections = splitSections(existingText);
+  const existingMap = new Map(existingSections.map((s) => [s.title, s.body]));
+
+  const merged = generatedSections.map((section) => {
+    if (!preserveTitles.has(section.title)) return section;
+    const existingBody = existingMap.get(section.title);
+    if (!existingBody || existingBody.trim().length === 0) return section;
+    return { ...section, body: existingBody };
+  });
+
+  const lines = [];
+  for (const section of merged) {
+    if (section.title === '__TOP__') {
+      if (section.body) lines.push(section.body);
+      continue;
+    }
+    lines.push(`## ${section.title}`);
+    if (section.body) lines.push(section.body);
+    lines.push('');
+  }
+  return lines.join('\n').trimEnd();
 }
 
 function findSectionByPrefix(markdown, headingPrefix) {
@@ -159,10 +213,20 @@ async function main() {
   const outputPath = path.resolve(args.outputDir, outputFileName);
 
   const specText = await fs.readFile(specPath, 'utf8');
-  const planText = buildPlanMarkdown(args.feature, specText);
+  const generatedPlanText = buildPlanMarkdown(args.feature, specText);
+  let planText = generatedPlanText;
+
+  if (args.mode === 'append-notes') {
+    try {
+      const existing = await fs.readFile(outputPath, 'utf8');
+      planText = mergePlanWithExisting(generatedPlanText, existing);
+    } catch {
+      planText = generatedPlanText;
+    }
+  }
 
   if (args.dryRun) {
-    console.log(`DRY-RUN: ${outputPath}`);
+    console.log(`DRY-RUN: ${outputPath} (mode=${args.mode})`);
     console.log(planText);
     return;
   }


### PR DESCRIPTION
## Summary
- add `--mode` option to `sync-spec-to-planning` (`overwrite`/`append-notes`)
- keep default behavior as `overwrite`
- in `append-notes` mode, preserve manual sections from existing planning file (`리스크`, `작업 단계`, `진행 상태`)
- update spec-kit adoption guide with mode usage and examples

## Verification
- `node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops --mode overwrite --dry-run`
- `node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops --mode append-notes --dry-run`
- `node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops --mode append-notes`

## Handoff
### 변경 파일 목록
- scripts/sync-spec-to-planning.mjs
- docs/guides/spec-kit-adoption.md
- docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md

### 검증 결과
- mode=overwrite: generated sections fully regenerated
- mode=append-notes: manual risk/status notes preserved after regeneration

### 남은 리스크
- preserve 대상 섹션은 현재 고정 목록이며, 추가 수동 섹션이 필요하면 목록 확장 필요