### PR TITLE
feat: add sync run summary reporting

### DIFF
--- a/docs/guides/spec-kit-adoption.md
+++ b/docs/guides/spec-kit-adoption.md
@@ -70,6 +70,9 @@ node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops -
 ```
 
 - 생성 대상: `docs/planning/exec-plans/active/<feature>.md`
+- 실행 후 요약 리포트가 출력된다:
+  - `total`, `created`, `updated`, `skipped`
+  - 처리 파일 목록
 - 모드:
   - `overwrite` (기본): 전체 재생성
   - `append-notes`: 기존 문서의 수동 구간(`리스크`, `작업 단계`, `진행 상태`) 보존

--- a/docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md
+++ b/docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md
@@ -1,7 +1,7 @@
 # FlowMind Finance VoiceOps MVP Execution Plan
 
 - source-spec: specs/001-flowmind-finance-voiceops/spec.md
-- generated-at: 2026-04-30T09:54:34.672Z
+- generated-at: 2026-04-30T09:58:51.146Z
 
 ## 제목
 - FlowMind Finance VoiceOps MVP

--- a/scripts/sync-spec-to-planning.mjs
+++ b/scripts/sync-spec-to-planning.mjs
@@ -215,6 +215,24 @@ function buildPlanMarkdown(featureId, specText) {
   ].join('\n');
 }
 
+function printSummary(results, dryRun) {
+  const created = results.filter((r) => r.action === 'created').length;
+  const updated = results.filter((r) => r.action === 'updated').length;
+  const skipped = results.filter((r) => r.action === 'skipped').length;
+
+  console.log('');
+  console.log('SYNC SUMMARY');
+  console.log(`- mode: ${dryRun ? 'dry-run' : 'apply'}`);
+  console.log(`- total: ${results.length}`);
+  console.log(`- created: ${created}`);
+  console.log(`- updated: ${updated}`);
+  console.log(`- skipped: ${skipped}`);
+  console.log('- files:');
+  for (const r of results) {
+    console.log(`  - [${r.action}] ${r.file}`);
+  }
+}
+
 async function main() {
   const args = parseArgs(process.argv);
   const targets = [];
@@ -240,6 +258,7 @@ async function main() {
     throw new Error('No spec targets found.');
   }
 
+  const results = [];
   for (const featureId of targets) {
     const specPath = path.resolve('specs', featureId, 'spec.md');
     const outputFileName = `${featureId}.md`;
@@ -248,26 +267,40 @@ async function main() {
     const specText = await fs.readFile(specPath, 'utf8');
     const generatedPlanText = buildPlanMarkdown(featureId, specText);
     let planText = generatedPlanText;
+    let existingText = null;
 
     if (args.mode === 'append-notes') {
       try {
-        const existing = await fs.readFile(outputPath, 'utf8');
-        planText = mergePlanWithExisting(generatedPlanText, existing);
+        existingText = await fs.readFile(outputPath, 'utf8');
+        planText = mergePlanWithExisting(generatedPlanText, existingText);
       } catch {
         planText = generatedPlanText;
       }
+    } else {
+      try {
+        existingText = await fs.readFile(outputPath, 'utf8');
+      } catch {
+        existingText = null;
+      }
     }
+
+    const nextText = `${planText}\n`;
+    const action = existingText === null ? 'created' : existingText === nextText ? 'skipped' : 'updated';
 
     if (args.dryRun) {
       console.log(`DRY-RUN: ${outputPath} (mode=${args.mode})`);
       console.log(planText);
+      results.push({ file: path.relative(process.cwd(), outputPath).replaceAll('\\', '/'), action });
       continue;
     }
 
     await fs.mkdir(path.dirname(outputPath), { recursive: true });
-    await fs.writeFile(outputPath, `${planText}\n`, 'utf8');
-    console.log(`Created: ${outputPath}`);
+    await fs.writeFile(outputPath, nextText, 'utf8');
+    console.log(`${action === 'created' ? 'Created' : action === 'updated' ? 'Updated' : 'Unchanged'}: ${outputPath}`);
+    results.push({ file: path.relative(process.cwd(), outputPath).replaceAll('\\', '/'), action });
   }
+
+  printSummary(results, args.dryRun);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- add execution summary reporting to `sync-spec-to-planning`
- summary includes total target count, created/updated/skipped counts, and file list
- apply same summary format for both `--dry-run` and actual apply mode
- update adoption guide with summary output behavior

## Verification
- `node scripts/sync-spec-to-planning.mjs --all --dry-run`
- `node scripts/sync-spec-to-planning.mjs --feature 001-flowmind-finance-voiceops`

## Handoff
### 변경 파일 목록
- scripts/sync-spec-to-planning.mjs
- docs/guides/spec-kit-adoption.md
- docs/planning/exec-plans/active/001-flowmind-finance-voiceops.md

### 검증 결과
- dry-run summary displayed (`total/created/updated/skipped` + files)
- apply summary displayed in same format

### 남은 리스크
- 현재 `updated/skipped` 판정은 파일 텍스트 비교 기반이라 라인엔딩 정책이 바뀌면 결과가 변동될 수 있음